### PR TITLE
Фикс запуска nfqws под линукс и мелкие улучшения

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -70,19 +70,20 @@ pub fn download_nfqws(version: &str) -> Result<(), String> {
     
     // Use local temp directory inside cache_dir to avoid Windows Defender blocks
     let tmp_dir = crate::config::get_cache_dir().join(".tmp_zapret_download");
+    let _ = fs::remove_dir_all(&tmp_dir);
     let _ = fs::create_dir_all(&tmp_dir);
     let tmp_archive = tmp_dir.join(&archive);
 
     println!("[nfqws] Downloading archive: {}", url);
-    let mut response = ureq::get(&url).call().map_err(|e| format!("Failed to download archive: {}", e))?.into_reader();
-    let mut file = fs::File::create(&tmp_archive).map_err(|e| format!("Failed to create temp file: {}", e))?;
-    std::io::copy(&mut response, &mut file).map_err(|e| format!("Failed to write archive: {}", e))?;
+    let mut response = ureq::get(&url).call().map_err(|e| format!("Ошибка скачивания архива: {}", e))?.into_reader();
+    let mut file = fs::File::create(&tmp_archive).map_err(|e| format!("Ошибка создания файла: {}", e))?;
+    std::io::copy(&mut response, &mut file).map_err(|e| format!("Ошибка записи архива: {}", e))?;
 
     println!("[nfqws] Extracting archive...");
-    let tar_gz = fs::File::open(&tmp_archive).map_err(|e| format!("Failed to open archive: {}", e))?;
+    let tar_gz = fs::File::open(&tmp_archive).map_err(|e| format!("Ошибка открытия архива: {}", e))?;
     let tar = flate2::read::GzDecoder::new(tar_gz);
     let mut archive = tar::Archive::new(tar);
-    archive.unpack(&tmp_dir).map_err(|e| format!("Failed to extract tar: {}", e))?;
+    archive.unpack(&tmp_dir).map_err(|e| format!("Ошибка распаковки tar: {}", e))?;
 
     let expected_bin_path = tmp_dir.join(format!("zapret-{}", tag)).join("binaries").join(platform);
 
@@ -102,7 +103,9 @@ pub fn download_nfqws(version: &str) -> Result<(), String> {
             let bin_name = "nfqws";
             let bin_file = expected_bin_path.join(bin_name);
             if bin_file.exists() {
-                fs::copy(&bin_file, bin_dir.join(bin_name)).map_err(|e| format!("Failed to copy binary: {}", e))?;
+                let dest = bin_dir.join(bin_name);
+                let _ = fs::remove_file(&dest);
+                fs::copy(&bin_file, &dest).map_err(|e| format!("Failed to copy binary: {}", e))?;
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
@@ -112,6 +115,16 @@ pub fn download_nfqws(version: &str) -> Result<(), String> {
                     }
                 }
                 println!("[nfqws] Successfully installed nfqws to bin/{}", bin_name);
+
+                // Set CAP_NET_ADMIN so nfqws can use nfqueue without full root
+                if let Ok(output) = std::process::Command::new("setcap")
+                    .args(["cap_net_admin+ep", bin_dir.join(bin_name).to_str().unwrap()])
+                    .output()
+                {
+                    if output.status.success() {
+                        println!("[nfqws] cap_net_admin+ep set on nfqws");
+                    }
+                }
             } else {
                 return Err(format!("Could not find {} in {:?}", bin_name, expected_bin_path));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,22 @@ fn main() {
     #[cfg(target_os = "windows")]
     platform::ensure_admin();
 
+    #[cfg(target_os = "linux")]
+    {
+        let not_root = std::process::Command::new("id")
+            .arg("-u")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim() != "0")
+            .unwrap_or(true);
+        if not_root {
+            eprintln!("Ошибка: для настройки nftables и nfqueue нужны права root.");
+            eprintln!("Запустите с sudo: sudo {} ...", std::env::current_exe().unwrap_or_default().display());
+            std::process::exit(1);
+        }
+    }
+
     let args = Cli::parse();
 
     if let Some(ref d) = args.cache_dir {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,7 +1,12 @@
 use crate::firewalls::FirewallBackend;
 use crate::strategy::{self, GameFilterPorts};
 use std::env;
+use std::fs;
 use std::path::Path;
+use std::process::{Child, Command};
+use std::sync::Mutex;
+
+static NFQWS_PROCESSES: Mutex<Vec<Child>> = Mutex::new(Vec::new());
 
 /// Run the zapret firewall rule setup and spawn the nfqws daemon.
 pub fn run_zapret(
@@ -11,10 +16,7 @@ pub fn run_zapret(
     use_udp: bool,
     backend: &dyn FirewallBackend,
 ) {
-    // 1. Clear existing firewall rules
-    let _ = backend.clear();
-
-    // 2. Parse strategy file
+    // 1. Parse strategy file
     let repo_dir = env::var("REPO_DIR").unwrap_or_else(|_| {
         crate::config::get_cache_dir()
             .join("zapret-discord-youtube-linux")
@@ -46,37 +48,88 @@ pub fn run_zapret(
         }
     };
 
-    // 3. Setup firewall
+    // 2. Setup firewall
     if let Err(e) = backend.setup(&parsed.tcp_ports, &parsed.udp_ports, interface) {
         println!("Error configuring firewall: {}", e);
     }
 
-    // 4. Start nfqws
-    println!("Запуск nfqws...");
-    let mut nfqws_args = vec![
-        "--daemon".to_string(),
-        "--dpi-desync-fwmark=0x40000000".to_string(),
-        "--qnum=200".to_string(),
-    ];
-    for param in parsed.nfqws_params {
-        for p in param.split_whitespace() {
-            nfqws_args.push(p.to_string());
+    // 3. Kill any leftover nfqws processes from previous runs
+    let _ = Command::new("pkill")
+        .arg("-9")
+        .arg("nfqws")
+        .output();
+
+    // 4. Ensure user list files exist (original scripts create empty ones)
+    let lists_dir = repo_path.join("lists");
+    for name in &["list-general-user.txt", "list-exclude-user.txt", "ipset-exclude-user.txt"] {
+        let path = lists_dir.join(name);
+        if !path.exists() {
+            let _ = fs::write(&path, "");
         }
     }
 
-    let bin_dir = crate::config::get_cache_dir().join("bin");
-    let bin_path = if env::consts::OS == "windows" {
-        bin_dir.join("winws.exe")
-    } else {
-        bin_dir.join("nfqws")
-    };
+    // 5. Start nfqws
+    println!("Запуск nfqws...");
 
-    println!("[Stub] {:?} spawned with args: {:?}", bin_path, nfqws_args);
+    let bin_dir = crate::config::get_cache_dir().join("bin");
+    let bin_name = if env::consts::OS == "windows" {
+        "winws.exe"
+    } else {
+        "nfqws"
+    };
+    let bin_path = bin_dir.join(bin_name);
+
+    if !bin_path.exists() {
+        println!("Бинарник не найден: {:?}. Сначала выполните установку зависимостей.", bin_path);
+        return;
+    }
+
+    // Set CAP_NET_ADMIN on binary so it can use nfqueue without root
+    let cap_status = Command::new("setcap")
+        .args(["cap_net_admin+ep", &bin_path.to_string_lossy()])
+        .output();
+    match cap_status {
+        Ok(o) if o.status.success() => (),
+        _ => println!("  (не удалось setcap cap_net_admin+ep, может потребоваться root)"),
+    }
+
+    let mut args = vec![
+        "--dpi-desync-fwmark=0x40000000".to_string(),
+        "--qnum=200".to_string(),
+    ];
+    for param in &parsed.nfqws_params {
+        for p in param.split_whitespace() {
+            let p = p.replace('"', "");
+            if !p.is_empty() && p != "^" {
+                args.push(p.to_string());
+            }
+        }
+    }
+
+    println!("  Команда: {:?} {:?}", bin_path, args);
+    match Command::new(&bin_path).args(&args).current_dir(&repo_path).spawn() {
+        Ok(child) => {
+            if let Ok(mut procs) = NFQWS_PROCESSES.lock() {
+                procs.push(child);
+            }
+            println!("  nfqws запущен");
+        }
+        Err(e) => {
+            println!("  Ошибка запуска nfqws: {}", e);
+        }
+    }
 }
 
 /// Clear the firewall rules and stop any running processes.
 pub fn stop_zapret(backend: &dyn FirewallBackend) {
-    println!("\n[Stub] Остановка nfqws...");
+    println!("\nОстановка nfqws...");
+    if let Ok(mut procs) = NFQWS_PROCESSES.lock() {
+        for child in procs.iter_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        procs.clear();
+    }
     let _ = backend.clear();
     println!("Очистка завершена.");
 }

--- a/src/strategy/parser.rs
+++ b/src/strategy/parser.rs
@@ -37,6 +37,7 @@ pub fn parse_bat_file(
 
     let raw = fs::read_to_string(file_path).map_err(|e| e.to_string())?;
     let mut content = raw.replace('\r', "");
+    content = regex::Regex::new(r"\^\s*\n").unwrap().replace_all(&content, "\n").to_string();
 
     // Replace static path placeholders.
     content = content.replace("%BIN%", "bin/");
@@ -96,7 +97,7 @@ pub fn parse_bat_file(
     let nfqws_params = filter_re
         .captures_iter(&content)
         .map(|caps| {
-            let args = caps[3]
+            let args = caps[0]
                 .split_whitespace()
                 .collect::<Vec<_>>()
                 .join(" ")

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -205,7 +205,9 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
             if res.is_ok() {
                 println!("\n✅ Download completed successfully. Press any key to return to the menu...");
             } else {
-                println!("\n❌ Download failed. Press any key to return to the menu...");
+                let err_msg = res.as_ref().unwrap_err();
+                println!("\n❌ Download failed: {}", err_msg);
+                println!("Press any key to return to the menu...");
             }
             
             // Wait for keypress
@@ -251,7 +253,9 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
             if res.is_ok() {
                 println!("\n✅ Download completed successfully. Press any key to return to the menu...");
             } else {
-                println!("\n❌ Download failed. Press any key to return to the menu...");
+                let err_msg = res.as_ref().unwrap_err();
+                println!("\n❌ Download failed: {}", err_msg);
+                println!("Press any key to return to the menu...");
             }
             
             // Wait for keypress


### PR DESCRIPTION
1. src/runner.rs — Реальный запуск nfqws (была заглушка)
- Заменён println!("[Stub] ...") на реальный Command::new().spawn() с отслеживанием Child-процессов через static NFQWS_PROCESSES: Mutex<Vec<Child>>
- stop_zapret() теперь убивает процессы и ждёт их завершения
- Убран --daemon из аргументов nfqws, чтобы процесс оставался дочерним и управлялся напрямую
- Убран дублирующийся backend.clear() (двойная очистка nftables)
- Добавлен current_dir() в корень репозитория стратегий, чтобы nfqws находил файлы bin/ и lists/
- Добавлено экранирование кавычек из аргументов (.replace('"', "")), фильтрация мусорных токенов (^)
- Добавлен pkill -9 nfqws перед запуском для убивания зависших процессов
- Добавлено создание пустых *-user.txt файлов в lists/, если их нет
- Добавлен вывод полной команды перед spawn (отладка)
- Добавлен setcap cap_net_admin+ep на бинарник перед запуском
2. src/strategy/parser.rs — Потеря --filter-* префиксов
- Исправлен captures group: caps[3] → caps[0], чтобы в аргументы nfqws попадал полный --filter-tcp=PORT ... а не только хвост после порта
- Добавлено удаление Windows line continuation (^\n) из содержимого .bat-файлов
3. src/download.rs — Установка зависимостей
- Добавлено удаление старого temp-директория перед распаковкой (fs::remove_dir_all)
- Добавлено удаление старого бинарника перед копированием (fs::remove_file), чтобы избежать "Text file busy"
- Добавлена установка cap_net_admin+ep на nfqws после копирования
- Улучшены сообщения об ошибках
4. src/main.rs — Проверка прав root
- Проверка вынесена в самое начало main()
- При отсутствии root программа завершается с ошибкой, а не просто предупреждает
- Работает только на Linux (#[cfg(target_os = "linux")])
5. src/tui/ui.rs — Вывод ошибок загрузки
- Вместо ❌ Download failed теперь выводится конкретная ошибка: ❌ Download failed: nfqws error: ...