### PR TITLE
Auto pkexec/sudo call

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,9 +93,39 @@ fn main() {
             .map(|s| s.trim() != "0")
             .unwrap_or(true);
         if not_root {
-            eprintln!("Ошибка: для настройки nftables и nfqueue нужны права root.");
-            eprintln!("Запустите с sudo: sudo {} ...", std::env::current_exe().unwrap_or_default().display());
-            std::process::exit(1);
+            println!("Для работы требуются права root. Попытка инициализации pkexec...");
+            let mut status = std::process::Command::new("pkexec")
+                .arg(std::env::current_exe().unwrap_or_default())
+                .args(std::env::args().skip(1))
+                .status();
+
+            let pkexec_failed = match &status {
+                Ok(st) => !st.success(),
+                Err(_) => true,
+            };
+
+            if pkexec_failed {
+                if let Ok(ref st) = status {
+                    eprintln!("pkexec завершился с ошибкой (код: {})", st);
+                } else if let Err(ref e) = status {
+                    eprintln!("Не удалось запустить pkexec: {}", e);
+                }
+                println!("Попытка инициализации sudo...");
+                status = std::process::Command::new("sudo")
+                    .arg(std::env::current_exe().unwrap_or_default())
+                    .args(std::env::args().skip(1))
+                    .status();
+            }
+
+            match status {
+                Ok(st) => {
+                    std::process::exit(st.code().unwrap_or(1));
+                }
+                Err(e) => {
+                    eprintln!("Ошибка запуска sudo/pkexec: {}. Попробуйте запустить вручную с правами root.", e);
+                    std::process::exit(1);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Автоматический вызов pkexec/sudo при запуске не от root

# Что было сделано
- При запуске после проверки root прав при их отсутствии вызывается pkexec (GUI вызов рут прав DE)
- При неудаче (pkexec отсутствует в системе/произошла ошибка) происходит fallback на sudo)