### PR TITLE
Сохранение выбора пользователя и проверка установленных зависимостей

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -76,3 +76,28 @@ pub fn get_cache_dir() -> std::path::PathBuf {
         std::path::PathBuf::from(".")
     }
 }
+
+const CONFIG_FILENAME: &str = "conf.env";
+
+pub fn config_path() -> std::path::PathBuf {
+    get_cache_dir().join(CONFIG_FILENAME)
+}
+
+pub fn save_config(cfg: &RunConfig) -> Result<(), String> {
+    let path = config_path();
+    let content = format!(
+        "interface={}\nstrategy={}\ngamefiltertcp={}\ngamefilterudp={}\n",
+        cfg.interface, cfg.strategy, cfg.gamefilter_tcp, cfg.gamefilter_udp
+    );
+    fs::write(&path, &content).map_err(|e| format!("Cannot write config '{}': {}", path.display(), e))?;
+    Ok(())
+}
+
+pub fn save_tui_state(interface: &str, strategy: &str, tcp: bool, udp: bool) -> Result<(), String> {
+    save_config(&RunConfig {
+        interface: interface.to_string(),
+        strategy: strategy.to_string(),
+        gamefilter_tcp: tcp,
+        gamefilter_udp: udp,
+    })
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -234,6 +234,47 @@ pub fn install_dependencies(nfqws_ver: &str, strat_ver: &str) -> Result<(), Stri
 }
 
 
+pub fn check_nfqws_installed() -> bool {
+    let bin_dir = crate::config::get_cache_dir().join("bin");
+    let bin_name = if env::consts::OS == "windows" {
+        "winws.exe"
+    } else {
+        "nfqws"
+    };
+    bin_dir.join(bin_name).exists()
+}
+
+pub fn check_strategies_installed() -> bool {
+    let repo_dir = crate::config::get_cache_dir().join("zapret-discord-youtube-linux");
+    if !repo_dir.exists() {
+        return false;
+    }
+    let mut has_bat = false;
+    if let Ok(entries) = std::fs::read_dir(&repo_dir) {
+        for entry in entries.flatten() {
+            if let Ok(name) = entry.file_name().into_string() {
+                if name.ends_with(".bat") {
+                    has_bat = true;
+                    break;
+                }
+            }
+        }
+    }
+    if !has_bat {
+        if let Ok(entries) = std::fs::read_dir(repo_dir.join("custom-strategies")) {
+            for entry in entries.flatten() {
+                if let Ok(name) = entry.file_name().into_string() {
+                    if name.ends_with(".bat") {
+                        has_bat = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    has_bat
+}
+
 pub fn fetch_repo_tags(repo: &str) -> Result<Vec<String>, String> {
     let url = format!("https://api.github.com/repos/{}/tags", repo);
     let req = ureq::get(&url)

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,15 @@ fn main() {
         use_strategy = app.strategies.get(app.selected_strategy).cloned();
         use_gamefilter_tcp = app.tcp_gamefilter;
         use_gamefilter_udp = app.udp_gamefilter;
+
+        if let Some(ref strat) = use_strategy {
+            let _ = config::save_tui_state(
+                &use_interface,
+                strat,
+                use_gamefilter_tcp,
+                use_gamefilter_udp,
+            );
+        }
     }
 
     let strategy_file = match use_strategy {

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,19 @@ fn main() {
         }
     };
 
+    let nfqws_ok = download::check_nfqws_installed();
+    let strat_ok = download::check_strategies_installed();
+    if !nfqws_ok || !strat_ok {
+        if !nfqws_ok && !strat_ok {
+            eprintln!("Ошибка: Отсутствуют оба компонента (nfqws и стратегии). Запуск отклонен.");
+        } else if !nfqws_ok {
+            eprintln!("Ошибка: Отсутствует nfqws (ядро). Запуск отклонен.");
+        } else {
+            eprintln!("Ошибка: Отсутствуют стратегии. Запуск отклонен.");
+        }
+        exit(1);
+    }
+
     #[cfg(not(target_os = "windows"))]
     let backend = NftablesBackend;
 

--- a/src/tui/menus/main_menu.rs
+++ b/src/tui/menus/main_menu.rs
@@ -24,9 +24,7 @@ pub fn render(app: &AppState) -> (Vec<ListItem<'static>>, &'static str, usize) {
     {
         let is_sel = app.main_menu == MainMenuState::DownloadDeps;
         if is_sel { selected_index = index; }
-        let nfqws_status = if app.nfqws_installed { "✅" } else { "❌" };
-        let strat_status = if app.strategies_installed { "✅" } else { "❌" };
-        items.push(ListItem::new(format!(" 📥 Dependencies: nfqws {} | strategies {} ", nfqws_status, strat_status)).style(
+        items.push(ListItem::new(" 📥 Dependencies Installer").style(
             if is_sel { Theme::selected_item() } else { Theme::normal_item() }
         ));
         index += 1;

--- a/src/tui/menus/main_menu.rs
+++ b/src/tui/menus/main_menu.rs
@@ -24,7 +24,9 @@ pub fn render(app: &AppState) -> (Vec<ListItem<'static>>, &'static str, usize) {
     {
         let is_sel = app.main_menu == MainMenuState::DownloadDeps;
         if is_sel { selected_index = index; }
-        items.push(ListItem::new(" 📥 Download Dependencies (nfqws / strategies)").style(
+        let nfqws_status = if app.nfqws_installed { "✅" } else { "❌" };
+        let strat_status = if app.strategies_installed { "✅" } else { "❌" };
+        items.push(ListItem::new(format!(" 📥 Dependencies: nfqws {} | strategies {} ", nfqws_status, strat_status)).style(
             if is_sel { Theme::selected_item() } else { Theme::normal_item() }
         ));
         index += 1;

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -227,6 +227,7 @@ pub struct AppState {
 
     pub nfqws_installed: bool,
     pub strategies_installed: bool,
+    pub dependency_error: Option<(String, std::time::Instant)>,
 }
 
 impl AppState {
@@ -284,6 +285,7 @@ impl AppState {
 
             nfqws_installed: crate::download::check_nfqws_installed(),
             strategies_installed: crate::download::check_strategies_installed(),
+            dependency_error: None,
         }
     }
 
@@ -383,7 +385,21 @@ impl AppState {
                         self.gamefilter_menu = GamefilterMenuState::Tcp;
                         self.status_message = None;
                     }
-                    MainMenuState::Run => self.should_run = true,
+                    MainMenuState::Run => {
+                        self.refresh_dep_status();
+                        if !self.nfqws_installed || !self.strategies_installed {
+                            let msg = if !self.nfqws_installed && !self.strategies_installed {
+                                "Ошибка: Отсутствуют оба компонента (nfqws и стратегии)"
+                            } else if !self.nfqws_installed {
+                                "Ошибка: Отсутствует nfqws (ядро)"
+                            } else {
+                                "Ошибка: Отсутствуют стратегии"
+                            };
+                            self.dependency_error = Some((msg.to_string(), std::time::Instant::now()));
+                        } else {
+                            self.should_run = true;
+                        }
+                    }
                     MainMenuState::Quit => self.should_quit = true,
                 }
             }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -224,18 +224,34 @@ pub struct AppState {
     pub should_download_zapret: bool,
     pub should_download_strategies: bool,
     pub status_message: Option<String>,
+
+    pub nfqws_installed: bool,
+    pub strategies_installed: bool,
 }
 
 impl AppState {
     pub fn new(interfaces: Vec<String>, strategies: Vec<String>) -> Self {
+        let saved_cfg = crate::config::load_config(
+            &crate::config::config_path().to_string_lossy()
+        ).ok();
+
+        let selected_interface = saved_cfg.as_ref().map_or(0, |cfg| {
+            interfaces.iter().position(|i| i == &cfg.interface).unwrap_or(0)
+        });
+        let selected_strategy = saved_cfg.as_ref().map_or(0, |cfg| {
+            strategies.iter().position(|s| s == &cfg.strategy).unwrap_or(0)
+        });
+        let tcp_gamefilter = saved_cfg.as_ref().map_or(false, |cfg| cfg.gamefilter_tcp);
+        let udp_gamefilter = saved_cfg.as_ref().map_or(false, |cfg| cfg.gamefilter_udp);
+
         Self {
             interfaces,
-            selected_interface: 0,
+            selected_interface,
             strategies,
-            selected_strategy: 0,
-            strategy_menu_index: 0,
-            tcp_gamefilter: false,
-            udp_gamefilter: false,
+            selected_strategy,
+            strategy_menu_index: selected_strategy,
+            tcp_gamefilter,
+            udp_gamefilter,
             active_screen: ActiveScreen::Main,
             
             #[cfg(target_os = "windows")]
@@ -265,7 +281,15 @@ impl AppState {
             should_download_zapret: false,
             should_download_strategies: false,
             status_message: None,
+
+            nfqws_installed: crate::download::check_nfqws_installed(),
+            strategies_installed: crate::download::check_strategies_installed(),
         }
+    }
+
+    pub fn refresh_dep_status(&mut self) {
+        self.nfqws_installed = crate::download::check_nfqws_installed();
+        self.strategies_installed = crate::download::check_strategies_installed();
     }
 
     #[cfg(target_os = "windows")]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -109,15 +109,30 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 list_state.select(Some(selected_index));
                 f.render_stateful_widget(list, main_chunks[0], &mut list_state);
 
-                let nfqws_status = if app.nfqws_installed { "✅" } else { "❌" };
-                let strat_status = if app.strategies_installed { "✅" } else { "❌" };
-                let status_text = Line::from(vec![
-                    Span::styled("📥 Dependencies Status: ", Style::default().fg(Color::Gray)),
-                    Span::styled("nfqws ", Style::default().fg(Color::White)),
-                    Span::raw(nfqws_status),
-                    Span::styled(" | strategies ", Style::default().fg(Color::White)),
-                    Span::raw(strat_status),
-                ]);
+                let mut show_error = false;
+                let mut error_msg = String::new();
+                if let Some((ref msg, instant)) = app.dependency_error {
+                    if instant.elapsed() < std::time::Duration::from_secs(3) {
+                        show_error = true;
+                        error_msg = msg.clone();
+                    }
+                }
+
+                let status_text = if show_error {
+                    Line::from(vec![
+                        Span::styled(error_msg, Style::default().fg(Color::Red).add_modifier(ratatui::style::Modifier::BOLD)),
+                    ])
+                } else {
+                    let nfqws_status = if app.nfqws_installed { "✅" } else { "❌" };
+                    let strat_status = if app.strategies_installed { "✅" } else { "❌" };
+                    Line::from(vec![
+                        Span::styled("📥 Dependencies Status: ", Style::default().fg(Color::Gray)),
+                        Span::styled("nfqws ", Style::default().fg(Color::White)),
+                        Span::raw(nfqws_status),
+                        Span::styled(" | strategies ", Style::default().fg(Color::White)),
+                        Span::raw(strat_status),
+                    ])
+                };
                 let status_paragraph = Paragraph::new(status_text)
                     .alignment(ratatui::layout::Alignment::Center);
                 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -228,6 +228,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
             } else {
                 app.status_message = Some("Zapret successfully downloaded and installed.".to_string());
                 app.active_screen = ActiveScreen::DownloadZapretSubmenu;
+                app.refresh_dep_status();
             }
         }
 
@@ -277,6 +278,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 app.status_message = Some("Strategies successfully downloaded and installed.".to_string());
                 app.strategies = crate::strategy::get_strategies();
                 app.active_screen = ActiveScreen::DownloadStrategiesSubmenu;
+                app.refresh_dep_status();
             }
         }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -91,14 +91,47 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 .border_type(BorderType::Rounded)
                 .border_style(Theme::dim_item());
 
-            let list = List::new(items)
-                .block(list_block)
-                .highlight_style(Style::default().add_modifier(ratatui::style::Modifier::ITALIC));
-            
-            let mut list_state = ratatui::widgets::ListState::default();
-            list_state.select(Some(selected_index));
-            
-            f.render_stateful_widget(list, chunks[1], &mut list_state);
+            if app.active_screen == ActiveScreen::Main {
+                let inner_area = list_block.inner(chunks[1]);
+                let main_chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([
+                        Constraint::Min(1),
+                        Constraint::Length(1),
+                    ])
+                    .split(inner_area);
+
+                f.render_widget(list_block, chunks[1]);
+
+                let list = List::new(items)
+                    .highlight_style(Style::default().add_modifier(ratatui::style::Modifier::ITALIC));
+                let mut list_state = ratatui::widgets::ListState::default();
+                list_state.select(Some(selected_index));
+                f.render_stateful_widget(list, main_chunks[0], &mut list_state);
+
+                let nfqws_status = if app.nfqws_installed { "✅" } else { "❌" };
+                let strat_status = if app.strategies_installed { "✅" } else { "❌" };
+                let status_text = Line::from(vec![
+                    Span::styled("📥 Dependencies Status: ", Style::default().fg(Color::Gray)),
+                    Span::styled("nfqws ", Style::default().fg(Color::White)),
+                    Span::raw(nfqws_status),
+                    Span::styled(" | strategies ", Style::default().fg(Color::White)),
+                    Span::raw(strat_status),
+                ]);
+                let status_paragraph = Paragraph::new(status_text)
+                    .alignment(ratatui::layout::Alignment::Center);
+                
+                f.render_widget(status_paragraph, main_chunks[1]);
+            } else {
+                let list = List::new(items)
+                    .block(list_block)
+                    .highlight_style(Style::default().add_modifier(ratatui::style::Modifier::ITALIC));
+                
+                let mut list_state = ratatui::widgets::ListState::default();
+                list_state.select(Some(selected_index));
+                
+                f.render_stateful_widget(list, chunks[1], &mut list_state);
+            }
 
             let dynamic_help = match app.active_screen {
                 ActiveScreen::Main => match app.main_menu {


### PR DESCRIPTION
1. Сохранение пользовательского выбора
- config.rs — добавлены функции save_config() и save_tui_state(). Сохраняет interface, strategy, gamefilter_tcp, gamefilter_udp в файл conf.env в cache-директории (рядом с бинарником или в ZAPRET_CACHE_DIR).
- state.rs — AppState::new() теперь загружает сохранённый conf.env при старте и восстанавливает последние значения интерфейса, стратегии и game filter.
- main.rs — после выхода из TUI (при запуске через Run) конфигурация автоматически сохраняется.
2. Детект установленных зависимостей
- download.rs — добавлены check_nfqws_installed() (проверяет bin/nfqws или bin/winws.exe) и check_strategies_installed() (ищет .bat файлы в zapret-discord-youtube-linux/).
- state.rs — в AppState добавлены поля nfqws_installed и strategies_installed, которые проверяются при создании и обновляются после загрузки (refresh_dep_status()).
- ui.rs — после успешной загрузки nfqws или стратегий вызывается refresh_dep_status().
- main_menu.rs — пункт "Download Dependencies" теперь показывает статус: ✅ nfqws / ❌ nfqws, ✅ strategies / ❌ strategies.