### PR TITLE
Добавление сервиса и поддержки различных init систем

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,6 +1802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,6 +1836,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-service"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9db37ecb5b13762d95468a2fc6009d4b2c62801243223aabd44fca13ad13c8"
+dependencies = [
+ "bitflags 1.3.2",
+ "widestring",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1880,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1889,6 +1930,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -1901,6 +1948,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -1910,6 +1963,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1931,6 +1990,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -1940,6 +2005,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1955,6 +2026,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -1964,6 +2041,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2126,6 +2209,7 @@ dependencies = [
  "serde_json",
  "tar",
  "ureq",
+ "windows-service",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ tar = "0.4.46"
 flate2 = "1.1.9"
 zip = "8.6.0"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-service = "0.6.0"
+
 [[bin]]
 name = "zapret-rust"
 path = "src/main.rs"

--- a/src/inits/dinit.rs
+++ b/src/inits/dinit.rs
@@ -1,0 +1,115 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use crate::inits::ServiceManager;
+
+pub struct DinitManager;
+
+impl DinitManager {
+    const SERVICE_PATH: &'static str = "/etc/dinit.d/zapret-rust";
+    const BOOT_DIR: &'static str = "/etc/dinit.d/boot.d";
+    const BOOT_LINK: &'static str = "/etc/dinit.d/boot.d/zapret-rust";
+    const SERVICE_NAME: &'static str = "zapret-rust";
+
+    fn run_dinitctl(&self, action: &str) -> Result<(), String> {
+        let output = Command::new("dinitctl")
+            .arg(action)
+            .arg(Self::SERVICE_NAME)
+            .output()
+            .map_err(|e| format!("Failed to execute dinitctl: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "dinitctl {} {} failed: {}",
+                action,
+                Self::SERVICE_NAME,
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+}
+
+impl ServiceManager for DinitManager {
+    fn is_installed(&self) -> bool {
+        Path::new(Self::SERVICE_PATH).exists()
+    }
+
+    fn is_active(&self) -> bool {
+        let output = Command::new("dinitctl")
+            .arg("status")
+            .arg(Self::SERVICE_NAME)
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                stdout.contains("Status: started") || stdout.contains("Status: running")
+            }
+            _ => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        let service_content = format!(
+            r#"type = simple
+command = {} --config {} --cache-dir {}
+restart = true
+restart-delay = 5
+"#,
+            exe_str, config_str, cache_str
+        );
+
+        fs::write(Self::SERVICE_PATH, service_content)
+            .map_err(|e| format!("Failed to write dinit service file: {}", e))?;
+
+        // Try to enable it by symlinking in boot.d
+        if let Err(e) = fs::create_dir_all(Self::BOOT_DIR) {
+            println!("  (could not create boot.d directory, auto-start might not work: {})", e);
+        } else {
+            if Path::new(Self::BOOT_LINK).exists() || fs::symlink_metadata(Self::BOOT_LINK).is_ok() {
+                let _ = fs::remove_file(Self::BOOT_LINK);
+            }
+            #[cfg(unix)]
+            {
+                let _ = std::os::unix::fs::symlink("../zapret-rust", Self::BOOT_LINK);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop service first (ignore errors)
+        let _ = self.run_dinitctl("stop");
+
+        // Remove boot.d symlink
+        if Path::new(Self::BOOT_LINK).exists() || fs::symlink_metadata(Self::BOOT_LINK).is_ok() {
+            let _ = fs::remove_file(Self::BOOT_LINK);
+        }
+
+        // Remove service file
+        if Path::new(Self::SERVICE_PATH).exists() {
+            fs::remove_file(Self::SERVICE_PATH)
+                .map_err(|e| format!("Failed to remove dinit service file: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_dinitctl("start")
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_dinitctl("stop")
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        self.run_dinitctl("restart")
+    }
+}

--- a/src/inits/init.rs
+++ b/src/inits/init.rs
@@ -1,0 +1,183 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use crate::inits::ServiceManager;
+
+pub struct InitManager;
+
+impl InitManager {
+    const SCRIPT_PATH: &'static str = "/etc/init.d/zapret-rust";
+    const SERVICE_NAME: &'static str = "zapret-rust";
+
+    fn run_init_script(&self, action: &str) -> Result<(), String> {
+        let output = Command::new(Self::SCRIPT_PATH)
+            .arg(action)
+            .output()
+            .map_err(|e| format!("Failed to execute init script: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "{} {} failed: {}",
+                Self::SCRIPT_PATH,
+                action,
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+
+    fn register_service(&self) -> Result<(), String> {
+        // Try update-rc.d first (Debian/Ubuntu/Devuan)
+        if Command::new("which").arg("update-rc.d").output().map(|o| o.status.success()).unwrap_or(false) {
+            let output = Command::new("update-rc.d")
+                .arg(Self::SERVICE_NAME)
+                .arg("defaults")
+                .output()
+                .map_err(|e| format!("Failed to execute update-rc.d: {}", e))?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                return Err(format!("update-rc.d failed: {}", stderr));
+            }
+        }
+        // Fallback to chkconfig (RedHat/CentOS/openSUSE)
+        else if Command::new("which").arg("chkconfig").output().map(|o| o.status.success()).unwrap_or(false) {
+            let output = Command::new("chkconfig")
+                .arg("--add")
+                .arg(Self::SERVICE_NAME)
+                .output()
+                .map_err(|e| format!("Failed to execute chkconfig: {}", e))?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                return Err(format!("chkconfig --add failed: {}", stderr));
+            }
+        }
+        Ok(())
+    }
+
+    fn unregister_service(&self) -> Result<(), String> {
+        if Command::new("which").arg("update-rc.d").output().map(|o| o.status.success()).unwrap_or(false) {
+            let _ = Command::new("update-rc.d")
+                .args(["-f", Self::SERVICE_NAME, "remove"])
+                .output();
+        } else if Command::new("which").arg("chkconfig").output().map(|o| o.status.success()).unwrap_or(false) {
+            let _ = Command::new("chkconfig")
+                .arg("--del")
+                .arg(Self::SERVICE_NAME)
+                .output();
+        }
+        Ok(())
+    }
+}
+
+impl ServiceManager for InitManager {
+    fn is_installed(&self) -> bool {
+        Path::new(Self::SCRIPT_PATH).exists()
+    }
+
+    fn is_active(&self) -> bool {
+        if !self.is_installed() {
+            return false;
+        }
+        let output = Command::new(Self::SCRIPT_PATH)
+            .arg("status")
+            .output();
+        match output {
+            Ok(out) => out.status.success(),
+            Err(_) => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        let script_content = format!(
+            r#"#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          zapret-rust
+# Required-Start:    $network $local_fs
+# Required-Stop:     $network $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Zapret Discord Youtube Service
+### END INIT INFO
+
+DESC="Zapret Discord Youtube Service"
+NAME="zapret-rust"
+DAEMON="{}"
+DAEMON_ARGS="--config {} --cache-dir {}"
+PIDFILE="/var/run/$NAME.pid"
+
+case "$1" in
+    start)
+        echo "Starting $DESC"
+        start-stop-daemon --start --background --make-pidfile --pidfile "$PIDFILE" --exec "$DAEMON" -- $DAEMON_ARGS
+        ;;
+    stop)
+        echo "Stopping $DESC"
+        start-stop-daemon --stop --pidfile "$PIDFILE" --retry 5
+        ;;
+    restart)
+        $0 stop
+        $0 start
+        ;;
+    status)
+        if [ -f "$PIDFILE" ] && kill -0 $(cat "$PIDFILE") 2>/dev/null; then
+            echo "$DESC is running"
+            exit 0
+        else
+            echo "$DESC is stopped"
+            exit 3
+        fi
+        ;;
+    *)
+        echo "Usage: $0 {{start|stop|restart|status}}"
+        exit 1
+        ;;
+esac
+"#,
+            exe_str, config_str, cache_str
+        );
+
+        fs::write(Self::SCRIPT_PATH, script_content)
+            .map_err(|e| format!("Failed to write SysV init script: {}", e))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(Self::SCRIPT_PATH, fs::Permissions::from_mode(0o755))
+                .map_err(|e| format!("Failed to set executable permissions on SysV init script: {}", e))?;
+        }
+
+        self.register_service()?;
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop service first (ignore errors)
+        let _ = self.run_init_script("stop");
+        let _ = self.unregister_service();
+
+        if Path::new(Self::SCRIPT_PATH).exists() {
+            fs::remove_file(Self::SCRIPT_PATH)
+                .map_err(|e| format!("Failed to remove SysV init script: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_init_script("start")
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_init_script("stop")
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        self.run_init_script("restart")
+    }
+}

--- a/src/inits/init_structure.md
+++ b/src/inits/init_structure.md
@@ -1,0 +1,8 @@
+# Methods
+1. `is_installed(&self) -> bool`
+2. `is_active(&self) -> bool`
+3. `install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String>`
+4. `uninstall(&self) -> Result<(), String>
+start(&self) -> Result<(), String>
+stop(&self) -> Result<(), String>`
+5. `restart(&self) -> Result<(), String>`

--- a/src/inits/mod.rs
+++ b/src/inits/mod.rs
@@ -1,0 +1,160 @@
+// Linux
+#[cfg(target_os = "linux")]
+pub mod init;
+#[cfg(target_os = "linux")]
+pub mod systemd;
+#[cfg(target_os = "linux")]
+pub mod openrc;
+#[cfg(target_os = "linux")]
+pub mod runit;
+#[cfg(target_os = "linux")]
+pub mod dinit;
+#[cfg(target_os = "linux")]
+pub mod s6;
+
+
+#[cfg(target_os = "linux")]
+pub use init::InitManager;
+#[cfg(target_os = "linux")]
+pub use systemd::SystemdManager;
+#[cfg(target_os = "linux")]
+pub use openrc::OpenRcManager;
+#[cfg(target_os = "linux")]
+pub use runit::RunitManager;
+#[cfg(target_os = "linux")]
+pub use dinit::DinitManager;
+#[cfg(target_os = "linux")]
+pub use s6::S6Manager;
+
+// Windows
+#[cfg(target_os = "windows")]
+pub mod winservice;
+
+#[cfg(target_os = "windows")]
+pub use winservice::WindowsServiceManager;
+
+use std::path::Path;
+
+pub trait ServiceManager: Send + Sync {
+    fn is_installed(&self) -> bool;
+    fn is_active(&self) -> bool;
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String>;
+    fn uninstall(&self) -> Result<(), String>;
+    fn start(&self) -> Result<(), String>;
+    fn stop(&self) -> Result<(), String>;
+    fn restart(&self) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitType {
+    #[cfg(target_os = "linux")]
+    Systemd,
+    #[cfg(target_os = "linux")]
+    OpenRc,
+    #[cfg(target_os = "linux")]
+    Runit,
+    #[cfg(target_os = "linux")]
+    Dinit,
+    #[cfg(target_os = "linux")]
+    S6,
+    #[cfg(target_os = "linux")]
+    Init,
+    #[cfg(target_os = "windows")]
+    Windows,
+}
+
+impl InitType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            #[cfg(target_os = "linux")]
+            Self::Systemd => "systemd",
+            #[cfg(target_os = "linux")]
+            Self::OpenRc => "openrc",
+            #[cfg(target_os = "linux")]
+            Self::Runit => "runit",
+            #[cfg(target_os = "linux")]
+            Self::Dinit => "dinit",
+            #[cfg(target_os = "linux")]
+            Self::S6 => "s6",
+            #[cfg(target_os = "linux")]
+            Self::Init => "init",
+            #[cfg(target_os = "windows")]
+            Self::Windows => "windows",
+        }
+    }
+}
+
+/// Detect the active init system of the running OS.
+pub fn detect_init_system() -> Option<InitType> {
+    #[cfg(target_os = "windows")]
+    {
+        return Some(InitType::Windows);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // 1. Check systemd (standard directory /run/systemd/system)
+        if Path::new("/run/systemd/system").exists() {
+            return Some(InitType::Systemd);
+        }
+
+        // 2. Check OpenRC
+        if Path::new("/run/openrc").exists() || Path::new("/sbin/openrc-run").exists() {
+            return Some(InitType::OpenRc);
+        }
+
+        // 3. Check dinit (usually dinitctl exists or checking process name/etc)
+        if Path::new("/etc/dinit.d").exists() {
+            if std::process::Command::new("which").arg("dinitctl").output().map(|o| o.status.success()).unwrap_or(false) {
+                return Some(InitType::Dinit);
+            }
+        }
+
+        // 4. Check runit (directory /etc/runit or command runsvdir/sv)
+        if Path::new("/etc/runit").exists() || Path::new("/var/service").exists() {
+            if std::process::Command::new("which").arg("sv").output().map(|o| o.status.success()).unwrap_or(false) {
+                return Some(InitType::Runit);
+            }
+        }
+
+        // 5. Check s6
+        if Path::new("/etc/s6").exists() {
+            if std::process::Command::new("which").arg("s6-svstat").output().map(|o| o.status.success()).unwrap_or(false) {
+                return Some(InitType::S6);
+            }
+        }
+
+        // 6. Check classic SysV Init
+        if Path::new("/etc/init.d").exists() {
+            return Some(InitType::Init);
+        }
+
+        None
+    }
+}
+
+/// Factory function to get the ServiceManager for the detected init system.
+pub fn get_detected_manager() -> Option<Box<dyn ServiceManager>> {
+    detect_init_system().map(|t| get_manager(t))
+}
+
+/// Factory function to get the ServiceManager for a specific InitType.
+pub fn get_manager(init_type: InitType) -> Box<dyn ServiceManager> {
+    match init_type {
+        #[cfg(target_os = "linux")]
+        InitType::Systemd => Box::new(SystemdManager),
+        #[cfg(target_os = "linux")]
+        InitType::OpenRc => Box::new(OpenRcManager),
+        #[cfg(target_os = "linux")]
+        InitType::Runit => Box::new(RunitManager),
+        #[cfg(target_os = "linux")]
+        InitType::Dinit => Box::new(DinitManager),
+        #[cfg(target_os = "linux")]
+        InitType::S6 => Box::new(S6Manager),
+        #[cfg(target_os = "linux")]
+        InitType::Init => Box::new(InitManager),
+        
+        #[cfg(target_os = "windows")]
+        InitType::Windows => Box::new(WindowsServiceManager),
+    }
+}

--- a/src/inits/openrc.rs
+++ b/src/inits/openrc.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use crate::inits::ServiceManager;
+
+pub struct OpenRcManager;
+
+impl OpenRcManager {
+    const SERVICE_NAME: &'static str = "zapret-rust";
+    const SCRIPT_PATH: &'static str = "/etc/init.d/zapret-rust";
+
+    fn run_rc_service(&self, action: &str) -> Result<(), String> {
+        let output = Command::new("rc-service")
+            .arg(Self::SERVICE_NAME)
+            .arg(action)
+            .output()
+            .map_err(|e| format!("Failed to execute rc-service: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "rc-service {} {} failed: {}",
+                Self::SERVICE_NAME,
+                action,
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+
+    fn run_rc_update(&self, action: &str, runlevel: &str) -> Result<(), String> {
+        let output = Command::new("rc-update")
+            .arg(action)
+            .arg(Self::SERVICE_NAME)
+            .arg(runlevel)
+            .output()
+            .map_err(|e| format!("Failed to execute rc-update: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "rc-update {} {} {} failed: {}",
+                action,
+                Self::SERVICE_NAME,
+                runlevel,
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+}
+
+impl ServiceManager for OpenRcManager {
+    fn is_installed(&self) -> bool {
+        Path::new(Self::SCRIPT_PATH).exists()
+    }
+
+    fn is_active(&self) -> bool {
+        let output = Command::new("rc-service")
+            .arg(Self::SERVICE_NAME)
+            .arg("status")
+            .output();
+        match output {
+            Ok(out) => out.status.success(),
+            Err(_) => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        let script_content = format!(
+            r#"#!/sbin/openrc-run
+
+description="Zapret Discord Youtube Service"
+supervisor="supervise-daemon"
+respawn_delay=5
+respawn_max=10
+
+command="{}"
+command_args="--config {} --cache-dir {}"
+
+depend() {{
+    need net
+    after firewall
+}}
+"#,
+            exe_str, config_str, cache_str
+        );
+
+        fs::write(Self::SCRIPT_PATH, script_content)
+            .map_err(|e| format!("Failed to write OpenRC init script: {}", e))?;
+
+        #[cfg(unix)]
+        {{
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(Self::SCRIPT_PATH, fs::Permissions::from_mode(0o755))
+                .map_err(|e| format!("Failed to set executable permissions on OpenRC script: {}", e))?;
+        }}
+
+        self.run_rc_update("add", "default")?;
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop service first (ignore errors)
+        let _ = self.run_rc_service("stop");
+        let _ = self.run_rc_update("del", "default");
+
+        if Path::new(Self::SCRIPT_PATH).exists() {
+            fs::remove_file(Self::SCRIPT_PATH)
+                .map_err(|e| format!("Failed to remove OpenRC init script: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_rc_service("start")
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_rc_service("stop")
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        self.run_rc_service("restart")
+    }
+}

--- a/src/inits/runit.rs
+++ b/src/inits/runit.rs
@@ -1,0 +1,134 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use crate::inits::ServiceManager;
+
+pub struct RunitManager;
+
+impl RunitManager {
+    const SV_DIR: &'static str = "/etc/sv/zapret-rust";
+    const SERVICE_NAME: &'static str = "zapret-rust";
+
+    fn get_link_path(&self) -> &'static str {
+        if Path::new("/service").exists() && !Path::new("/var/service").exists() {
+            "/service/zapret-rust"
+        } else {
+            "/var/service/zapret-rust"
+        }
+    }
+
+    fn run_sv(&self, action: &str) -> Result<(), String> {
+        let output = Command::new("sv")
+            .arg(action)
+            .arg(Self::SERVICE_NAME)
+            .output()
+            .map_err(|e| format!("Failed to execute sv: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "sv {} {} failed: {}",
+                action,
+                Self::SERVICE_NAME,
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+}
+
+impl ServiceManager for RunitManager {
+    fn is_installed(&self) -> bool {
+        Path::new(Self::SV_DIR).exists()
+    }
+
+    fn is_active(&self) -> bool {
+        let output = Command::new("sv")
+            .arg("status")
+            .arg(Self::SERVICE_NAME)
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                stdout.trim().starts_with("run:")
+            }
+            _ => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        // 1. Create SV dir
+        fs::create_dir_all(Self::SV_DIR)
+            .map_err(|e| format!("Failed to create runit service directory: {}", e))?;
+
+        // 2. Write run file
+        let run_path = Path::new(Self::SV_DIR).join("run");
+        let run_content = format!(
+            r#"#!/bin/sh
+exec 2>&1
+exec {} --config {} --cache-dir {}
+"#,
+            exe_str, config_str, cache_str
+        );
+        fs::write(&run_path, run_content)
+            .map_err(|e| format!("Failed to write run script: {}", e))?;
+
+        // 3. Make run script executable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&run_path, fs::Permissions::from_mode(0o755))
+                .map_err(|e| format!("Failed to set run script as executable: {}", e))?;
+        }
+
+        // 4. Link service
+        let link_path = self.get_link_path();
+        if Path::new(link_path).exists() || fs::symlink_metadata(link_path).is_ok() {
+            let _ = fs::remove_file(link_path);
+        }
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(Self::SV_DIR, link_path)
+                .map_err(|e| format!("Failed to create symlink at {}: {}", link_path, e))?;
+        }
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop the service
+        let _ = self.run_sv("stop");
+
+        // Remove symlink
+        let link_path = self.get_link_path();
+        if Path::new(link_path).exists() || fs::symlink_metadata(link_path).is_ok() {
+            fs::remove_file(link_path)
+                .map_err(|e| format!("Failed to remove symlink {}: {}", link_path, e))?;
+        }
+
+        // Remove sv directory
+        if Path::new(Self::SV_DIR).exists() {
+            fs::remove_dir_all(Self::SV_DIR)
+                .map_err(|e| format!("Failed to remove runit service directory: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_sv("start")
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_sv("stop")
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        self.run_sv("restart")
+    }
+}

--- a/src/inits/s6.rs
+++ b/src/inits/s6.rs
@@ -1,0 +1,104 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use crate::inits::ServiceManager;
+
+pub struct S6Manager;
+
+impl S6Manager {
+    const SERVICE_DIR: &'static str = "/etc/s6/services/zapret-rust";
+
+    fn run_s6_svc(&self, flag: &str) -> Result<(), String> {
+        let output = Command::new("s6-svc")
+            .arg(flag)
+            .arg(Self::SERVICE_DIR)
+            .output()
+            .map_err(|e| format!("Failed to execute s6-svc: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "s6-svc {} {} failed: {}",
+                flag,
+                Self::SERVICE_DIR,
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+}
+
+impl ServiceManager for S6Manager {
+    fn is_installed(&self) -> bool {
+        Path::new(Self::SERVICE_DIR).exists()
+    }
+
+    fn is_active(&self) -> bool {
+        let output = Command::new("s6-svstat")
+            .arg(Self::SERVICE_DIR)
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                stdout.contains("up (pid")
+            }
+            _ => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        // 1. Create S6 dir
+        fs::create_dir_all(Self::SERVICE_DIR)
+            .map_err(|e| format!("Failed to create s6 service directory: {}", e))?;
+
+        // 2. Write run file
+        let run_path = Path::new(Self::SERVICE_DIR).join("run");
+        let run_content = format!(
+            r#"#!/bin/sh
+exec {} --config {} --cache-dir {}
+"#,
+            exe_str, config_str, cache_str
+        );
+        fs::write(&run_path, run_content)
+            .map_err(|e| format!("Failed to write run script: {}", e))?;
+
+        // 3. Make run script executable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&run_path, fs::Permissions::from_mode(0o755))
+                .map_err(|e| format!("Failed to set run script as executable: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop service first (ignore errors)
+        let _ = self.run_s6_svc("-d");
+
+        // Remove service directory
+        if Path::new(Self::SERVICE_DIR).exists() {
+            fs::remove_dir_all(Self::SERVICE_DIR)
+                .map_err(|e| format!("Failed to remove s6 service directory: {}", e))?;
+        }
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_s6_svc("-u")
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_s6_svc("-d")
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        self.run_s6_svc("-r")
+    }
+}

--- a/src/inits/systemd.rs
+++ b/src/inits/systemd.rs
@@ -1,0 +1,103 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use crate::inits::ServiceManager;
+
+pub struct SystemdManager;
+
+impl SystemdManager {
+    const SERVICE_NAME: &'static str = "zapret-rust";
+    const SERVICE_PATH: &'static str = "/etc/systemd/system/zapret-rust.service";
+
+    fn run_command(&self, args: &[&str]) -> Result<(), String> {
+        let output = Command::new("systemctl")
+            .args(args)
+            .output()
+            .map_err(|e| format!("Failed to execute systemctl: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(format!(
+                "systemctl {} failed: {}",
+                args.join(" "),
+                if stderr.is_empty() { format!("exit code {:?}", output.status.code()) } else { stderr }
+            ))
+        }
+    }
+}
+
+impl ServiceManager for SystemdManager {
+    fn is_installed(&self) -> bool {
+        Path::new(Self::SERVICE_PATH).exists()
+    }
+
+    fn is_active(&self) -> bool {
+        let output = Command::new("systemctl")
+            .arg("is-active")
+            .arg(Self::SERVICE_NAME)
+            .output();
+        match output {
+            Ok(out) => out.status.success(),
+            Err(_) => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        let service_content = format!(
+            r#"[Unit]
+Description=Zapret Discord Youtube Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={} --config {} --cache-dir {}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+"#,
+            exe_str, config_str, cache_str
+        );
+
+        fs::write(Self::SERVICE_PATH, service_content)
+            .map_err(|e| format!("Failed to write service file: {}", e))?;
+
+        self.run_command(&["daemon-reload"])?;
+        self.run_command(&["enable", Self::SERVICE_NAME])?;
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop service first (ignore errors if it's not running or doesn't exist)
+        let _ = self.run_command(&["stop", Self::SERVICE_NAME]);
+        let _ = self.run_command(&["disable", Self::SERVICE_NAME]);
+
+        if Path::new(Self::SERVICE_PATH).exists() {
+            fs::remove_file(Self::SERVICE_PATH)
+                .map_err(|e| format!("Failed to remove service file: {}", e))?;
+        }
+
+        self.run_command(&["daemon-reload"])?;
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_command(&["start", Self::SERVICE_NAME])
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_command(&["stop", Self::SERVICE_NAME])
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        self.run_command(&["restart", Self::SERVICE_NAME])
+    }
+}

--- a/src/inits/winservice.rs
+++ b/src/inits/winservice.rs
@@ -1,0 +1,239 @@
+#![cfg(target_os = "windows")]
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+use crate::inits::ServiceManager;
+
+// We will use standard windows-service API when compiling on Windows
+use windows_service::{
+    define_windows_service,
+    service::{
+        ServiceControl, ServiceControlAccept, ServiceExitCode, ServiceState, ServiceStatus,
+        ServiceType,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult, ServiceStatusHandle},
+    service_dispatcher,
+};
+
+pub struct WindowsServiceManager;
+
+impl WindowsServiceManager {
+    const SERVICE_NAME: &'static str = "zapret-rust";
+
+    fn run_sc(&self, args: &[&str]) -> Result<(), String> {
+        let output = Command::new("sc")
+            .args(args)
+            .output()
+            .map_err(|e| format!("Failed to execute sc: {}", e))?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Err(format!(
+                "sc {} failed: {}",
+                args.join(" "),
+                if stderr.is_empty() { stdout } else { stderr }
+            ))
+        }
+    }
+}
+
+impl ServiceManager for WindowsServiceManager {
+    fn is_installed(&self) -> bool {
+        let output = Command::new("sc")
+            .arg("query")
+            .arg(Self::SERVICE_NAME)
+            .output();
+        match output {
+            Ok(out) => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                // If the service doesn't exist, sc query fails (often code 1060) and doesn't contain the service name
+                out.status.success() || stdout.contains("SERVICE_NAME")
+            }
+            Err(_) => false,
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        let output = Command::new("sc")
+            .arg("query")
+            .arg(Self::SERVICE_NAME)
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                stdout.contains("RUNNING")
+            }
+            _ => false,
+        }
+    }
+
+    fn install(&self, exe_path: &Path, config_path: &Path, cache_dir: &Path) -> Result<(), String> {
+        let exe_str = exe_path.to_str().ok_or("Invalid executable path")?;
+        let config_str = config_path.to_str().ok_or("Invalid config path")?;
+        let cache_str = cache_dir.to_str().ok_or("Invalid cache directory path")?;
+
+        // Format binPath with correct arguments. SCM expects space after 'binPath=' and 'start='
+        let bin_path_arg = format!(
+            "\"{}\" --service --config \"{}\" --cache-dir \"{}\"",
+            exe_str, config_str, cache_str
+        );
+
+        self.run_sc(&[
+            "create",
+            Self::SERVICE_NAME,
+            &format!("binPath= {}", bin_path_arg),
+            "start= auto",
+        ])?;
+
+        Ok(())
+    }
+
+    fn uninstall(&self) -> Result<(), String> {
+        // Stop service first (ignore errors)
+        let _ = Command::new("sc").arg("stop").arg(Self::SERVICE_NAME).output();
+        thread::sleep(Duration::from_millis(500));
+
+        self.run_sc(&["delete", Self::SERVICE_NAME])?;
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), String> {
+        self.run_sc(&["start", Self::SERVICE_NAME])
+    }
+
+    fn stop(&self) -> Result<(), String> {
+        self.run_sc(&["stop", Self::SERVICE_NAME])
+    }
+
+    fn restart(&self) -> Result<(), String> {
+        let _ = self.stop();
+        thread::sleep(Duration::from_secs(1));
+        self.start()
+    }
+}
+
+// Windows Service Runtime Implementation
+static RUNNING: AtomicBool = AtomicBool::new(true);
+
+define_windows_service!(ffi_service_main, my_service_main);
+
+pub fn run_service() -> Result<(), String> {
+    service_dispatcher::start(WindowsServiceManager::SERVICE_NAME, ffi_service_main)
+        .map_err(|e| format!("Failed to start service dispatcher: {}", e))
+}
+
+fn my_service_main(_arguments: Vec<std::ffi::OsString>) {
+    let status_handle = match service_control_handler::register(
+        WindowsServiceManager::SERVICE_NAME,
+        move |control_event| -> ServiceControlHandlerResult {
+            match control_event {
+                ServiceControl::Stop => {
+                    RUNNING.store(false, Ordering::SeqCst);
+                    ServiceControlHandlerResult::NoError
+                }
+                ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+                _ => ServiceControlHandlerResult::NotImplemented,
+            }
+        },
+    ) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    // Report Running state
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state: ServiceState::Running,
+        controls_accepted: ServiceControlAccept::STOP,
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    });
+
+    // Parse options from standard arguments (since binPath arguments are passed to the process)
+    let args: Vec<String> = std::env::args().collect();
+    let mut config_path = None;
+    let mut cache_dir = None;
+
+    for i in 0..args.len() {
+        if args[i] == "--config" && i + 1 < args.len() {
+            config_path = Some(args[i + 1].clone());
+        } else if args[i] == "--cache-dir" && i + 1 < args.len() {
+            cache_dir = Some(args[i + 1].clone());
+        }
+    }
+
+    let config_file = match config_path {
+        Some(c) => c,
+        None => {
+            report_stopped(&status_handle, 1);
+            return;
+        }
+    };
+
+    if let Some(ref d) = cache_dir {
+        std::env::set_var("ZAPRET_CACHE_DIR", d);
+    }
+
+    // Load Configuration
+    let cfg = match crate::config::load_config(&config_file) {
+        Ok(c) => c,
+        Err(_) => {
+            report_stopped(&status_handle, 2);
+            return;
+        }
+    };
+
+    // Run Zapret background loop
+    let backend = crate::firewalls::windivert::WinDivertBackend;
+
+    crate::runner::run_zapret(
+        &cfg.strategy,
+        &cfg.interface,
+        cfg.gamefilter_tcp,
+        cfg.gamefilter_udp,
+        &backend,
+    );
+
+    // Main service loop
+    while RUNNING.load(Ordering::SeqCst) {
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    // Cleanup and stop
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state: ServiceState::StopPending,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: ServiceExitCode::Win32(0),
+        checkpoint: 0,
+        wait_hint: Duration::from_secs(5),
+        process_id: None,
+    });
+
+    crate::runner::stop_zapret(&backend);
+
+    report_stopped(&status_handle, 0);
+}
+
+fn report_stopped(status_handle: &ServiceStatusHandle, exit_code: u32) {
+    let _ = status_handle.set_service_status(ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state: ServiceState::Stopped,
+        controls_accepted: ServiceControlAccept::empty(),
+        exit_code: if exit_code == 0 {
+            ServiceExitCode::Win32(0)
+        } else {
+            ServiceExitCode::Win32(exit_code)
+        },
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod download;
 mod firewalls;
+pub mod inits;
 mod platform;
 mod runner;
 mod strategy;
@@ -80,6 +81,17 @@ fn show_help() {
 }
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    {
+        if std::env::args().any(|arg| arg == "--service") {
+            if let Err(e) = inits::winservice::run_service() {
+                eprintln!("Service error: {}", e);
+                std::process::exit(1);
+            }
+            return;
+        }
+    }
+
     platform::ensure_admin();
 
     let args = Cli::parse();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -93,10 +93,18 @@ pub fn run_zapret(
         _ => println!("  (не удалось setcap cap_net_admin+ep, может потребоваться root)"),
     }
 
+    #[cfg(target_os = "linux")]
     let mut args = vec![
         "--dpi-desync-fwmark=0x40000000".to_string(),
         "--qnum=200".to_string(),
     ];
+
+    #[cfg(target_os = "windows")]
+    let mut args = vec![
+        format!("--wf-tcp={}", parsed.tcp_ports),
+        format!("--wf-udp={}", parsed.udp_ports),
+    ];
+
     for param in &parsed.nfqws_params {
         for p in param.split_whitespace() {
             let p = p.replace('"', "");

--- a/src/tui/menus/main_menu.rs
+++ b/src/tui/menus/main_menu.rs
@@ -87,11 +87,21 @@ pub fn render(app: &AppState) -> (Vec<ListItem<'static>>, &'static str, usize) {
         index += 1;
     }
 
+    // ServiceSettings
+    {
+        let is_sel = app.main_menu == MainMenuState::ServiceSettings;
+        if is_sel { selected_index = index; }
+        items.push(ListItem::new(" ⚙️ Service Settings").style(
+            if is_sel { Theme::selected_item() } else { Theme::normal_item() }
+        ));
+        index += 1;
+    }
+
     // Run
     {
         let is_sel = app.main_menu == MainMenuState::Run;
         if is_sel { selected_index = index; }
-        items.push(ListItem::new(" ▶️  Run Zapret").style(
+        items.push(ListItem::new(" ▶️ Run Zapret").style(
             if is_sel { Theme::selected_item() } else { Theme::normal_item() }
         ));
         index += 1;

--- a/src/tui/menus/mod.rs
+++ b/src/tui/menus/mod.rs
@@ -6,3 +6,5 @@ pub mod download_menu;
 pub mod download_submenu;
 pub mod tag_menu;
 pub mod gamefilter_menu;
+pub mod service_menu;
+

--- a/src/tui/menus/service_menu.rs
+++ b/src/tui/menus/service_menu.rs
@@ -1,0 +1,37 @@
+use ratatui::widgets::ListItem;
+use crate::tui::state::AppState;
+use crate::tui::theme::Theme;
+
+pub fn render(app: &AppState) -> (Vec<ListItem<'static>>, &'static str, usize) {
+    let mut menu_items = vec![];
+    
+    if !app.service_installed {
+        menu_items.push(" ▶️ Start Service".to_string());
+        menu_items.push(" 🔙 Back".to_string());
+    } else if app.service_active {
+        menu_items.push(" ⏹️ Stop Service".to_string());
+        menu_items.push(" 🔄 Restart Service".to_string());
+        menu_items.push(" 🗑️ Uninstall Service".to_string());
+        menu_items.push(" 🔙 Back".to_string());
+    } else {
+        menu_items.push(" ▶️ Start Service".to_string());
+        menu_items.push(" 🗑️ Uninstall Service".to_string());
+        menu_items.push(" 🔙 Back".to_string());
+    }
+
+    let selected_index = app.service_menu_index;
+
+    let items: Vec<ListItem> = menu_items
+        .into_iter()
+        .enumerate()
+        .map(|(i, m)| {
+            if i == selected_index {
+                ListItem::new(m).style(Theme::selected_item())
+            } else {
+                ListItem::new(m).style(Theme::normal_item())
+            }
+        })
+        .collect();
+
+    (items, " Service Management ", selected_index)
+}

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,4 +1,4 @@
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum ActiveScreen {
     Main,
     #[cfg(target_os = "windows")]
@@ -10,9 +10,10 @@ pub enum ActiveScreen {
     GamefilterSubmenu,
     ZapretTagSelect,
     StrategyTagSelect,
+    ServiceSubmenu,
 }
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum MainMenuState {
     #[cfg(target_os = "windows")]
     DefenderSettings,
@@ -20,6 +21,7 @@ pub enum MainMenuState {
     Interface,
     Strategy,
     GamefilterSettings,
+    ServiceSettings,
     Run,
     Quit,
 }
@@ -32,7 +34,8 @@ impl MainMenuState {
             Self::DownloadDeps => Self::Interface,
             Self::Interface => Self::Strategy,
             Self::Strategy => Self::GamefilterSettings,
-            Self::GamefilterSettings => Self::Run,
+            Self::GamefilterSettings => Self::ServiceSettings,
+            Self::ServiceSettings => Self::Run,
             Self::Run => Self::Quit,
             #[cfg(target_os = "windows")]
             Self::Quit => Self::DefenderSettings,
@@ -52,11 +55,13 @@ impl MainMenuState {
             Self::Interface => Self::DownloadDeps,
             Self::Strategy => Self::Interface,
             Self::GamefilterSettings => Self::Strategy,
-            Self::Run => Self::GamefilterSettings,
+            Self::ServiceSettings => Self::GamefilterSettings,
+            Self::Run => Self::ServiceSettings,
             Self::Quit => Self::Run,
         }
     }
 }
+
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum GamefilterMenuState {
@@ -232,6 +237,10 @@ pub struct AppState {
     pub nfqws_installed: bool,
     pub strategies_installed: bool,
     pub dependency_error: Option<(String, std::time::Instant)>,
+
+    pub service_installed: bool,
+    pub service_active: bool,
+    pub service_menu_index: usize,
 }
 
 impl AppState {
@@ -249,7 +258,7 @@ impl AppState {
         let tcp_gamefilter = saved_cfg.as_ref().map_or(false, |cfg| cfg.gamefilter_tcp);
         let udp_gamefilter = saved_cfg.as_ref().map_or(false, |cfg| cfg.gamefilter_udp);
 
-        Self {
+        let mut app = Self {
             interfaces,
             selected_interface,
             strategies,
@@ -291,7 +300,13 @@ impl AppState {
             nfqws_installed: crate::download::check_nfqws_installed(),
             strategies_installed: crate::download::check_strategies_installed(),
             dependency_error: None,
-        }
+
+            service_installed: false,
+            service_active: false,
+            service_menu_index: 0,
+        };
+        app.refresh_service_status();
+        app
     }
 
     pub fn refresh_dep_status(&mut self) {
@@ -302,6 +317,41 @@ impl AppState {
     #[cfg(target_os = "windows")]
     pub fn refresh_defender_status(&mut self) {
         self.defender_status_cache = crate::defender::check_defender_exclusion().ok();
+    }
+
+    pub fn refresh_service_status(&mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            if let Some(mgr) = crate::inits::get_detected_manager() {
+                self.service_installed = mgr.is_installed();
+                self.service_active = mgr.is_active();
+            } else {
+                self.service_installed = false;
+                self.service_active = false;
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            use crate::inits::ServiceManager;
+            let mgr = crate::inits::winservice::WindowsServiceManager;
+            self.service_installed = mgr.is_installed();
+            self.service_active = mgr.is_active();
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            self.service_installed = false;
+            self.service_active = false;
+        }
+    }
+
+    pub fn get_service_menu_count(&self) -> usize {
+        if !self.service_installed {
+            2
+        } else if self.service_active {
+            4
+        } else {
+            3
+        }
     }
 
     pub fn next_menu(&mut self) {
@@ -326,6 +376,12 @@ impl AppState {
             ActiveScreen::StrategyTagSelect => {
                 if !self.available_strat_tags.is_empty() {
                     self.strat_tag_index = (self.strat_tag_index + 1) % (self.available_strat_tags.len() + 1);
+                }
+            }
+            ActiveScreen::ServiceSubmenu => {
+                let count = self.get_service_menu_count();
+                if count > 0 {
+                    self.service_menu_index = (self.service_menu_index + 1) % count;
                 }
             }
         }
@@ -356,6 +412,12 @@ impl AppState {
                 if !self.available_strat_tags.is_empty() {
                     let max = self.available_strat_tags.len() + 1;
                     self.strat_tag_index = (self.strat_tag_index + max - 1) % max;
+                }
+            }
+            ActiveScreen::ServiceSubmenu => {
+                let count = self.get_service_menu_count();
+                if count > 0 {
+                    self.service_menu_index = (self.service_menu_index + count - 1) % count;
                 }
             }
         }
@@ -390,15 +452,21 @@ impl AppState {
                         self.gamefilter_menu = GamefilterMenuState::Tcp;
                         self.status_message = None;
                     }
+                    MainMenuState::ServiceSettings => {
+                        self.active_screen = ActiveScreen::ServiceSubmenu;
+                        self.service_menu_index = 0;
+                        self.refresh_service_status();
+                        self.status_message = None;
+                    }
                     MainMenuState::Run => {
                         self.refresh_dep_status();
                         if !self.nfqws_installed || !self.strategies_installed {
                             let msg = if !self.nfqws_installed && !self.strategies_installed {
-                                "Ошибка: Отсутствуют оба компонента (nfqws и стратегии)"
+                                "Error: Both components (nfqws and strategies) are missing"
                             } else if !self.nfqws_installed {
-                                "Ошибка: Отсутствует nfqws (ядро)"
+                                "Error: nfqws (core) is missing"
                             } else {
-                                "Ошибка: Отсутствуют стратегии"
+                                "Error: strategies are missing"
                             };
                             self.dependency_error = Some((msg.to_string(), std::time::Instant::now()));
                         } else {
@@ -552,6 +620,90 @@ impl AppState {
                         self.active_screen = ActiveScreen::Main;
                         self.status_message = None;
                     }
+                }
+            }
+            ActiveScreen::ServiceSubmenu => {
+                #[cfg(target_os = "linux")]
+                let mgr_opt = crate::inits::get_detected_manager();
+                #[cfg(target_os = "windows")]
+                let mgr_opt: Option<Box<dyn crate::inits::ServiceManager>> = Some(Box::new(crate::inits::winservice::WindowsServiceManager));
+                #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+                let mgr_opt: Option<Box<dyn crate::inits::ServiceManager>> = None;
+
+                if let Some(mgr) = mgr_opt {
+                    let mut action_taken = true;
+                    let res = if !self.service_installed {
+                        match self.service_menu_index {
+                            0 => {
+                                let exe_path = std::env::current_exe().map_err(|e| e.to_string());
+                                match exe_path {
+                                    Ok(p) => {
+                                        let config_path = crate::config::config_path();
+                                        let cache_dir = crate::config::get_cache_dir();
+                                        mgr.install(&p, &config_path, &cache_dir)
+                                            .and_then(|_| mgr.start())
+                                    }
+                                    Err(e) => Err(e),
+                                }
+                            }
+                            1 => {
+                                self.active_screen = ActiveScreen::Main;
+                                self.status_message = None;
+                                action_taken = false;
+                                Ok(())
+                            }
+                            _ => {
+                                action_taken = false;
+                                Ok(())
+                            }
+                        }
+                    } else if self.service_active {
+                        match self.service_menu_index {
+                            0 => mgr.stop(),
+                            1 => mgr.restart(),
+                            2 => mgr.uninstall(),
+                            3 => {
+                                self.active_screen = ActiveScreen::Main;
+                                self.status_message = None;
+                                action_taken = false;
+                                Ok(())
+                            }
+                            _ => {
+                                action_taken = false;
+                                Ok(())
+                            }
+                        }
+                    } else {
+                        match self.service_menu_index {
+                            0 => mgr.start(),
+                            1 => mgr.uninstall(),
+                            2 => {
+                                self.active_screen = ActiveScreen::Main;
+                                self.status_message = None;
+                                action_taken = false;
+                                Ok(())
+                            }
+                            _ => {
+                                action_taken = false;
+                                Ok(())
+                            }
+                        }
+                    };
+
+                    if action_taken {
+                        match res {
+                            Ok(_) => {
+                                self.refresh_service_status();
+                                self.service_menu_index = 0;
+                                self.status_message = Some("✅ Operation completed successfully.".to_string());
+                            }
+                            Err(e) => {
+                                self.status_message = Some(format!("❌ Error: {}", e));
+                            }
+                        }
+                    }
+                } else {
+                    self.status_message = Some("❌ Error: Init system not supported.".to_string());
                 }
             }
         }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -59,6 +59,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 ActiveScreen::GamefilterSubmenu => " 🎮 Game Filter Settings ",
                 ActiveScreen::ZapretTagSelect => " 🏷️ Select Zapret Tag ",
                 ActiveScreen::StrategyTagSelect => " 🏷️ Select Strategies Tag ",
+                ActiveScreen::ServiceSubmenu => " ⚙️ Service Management ",
             };
 
             let title = Paragraph::new(Line::from(vec![
@@ -83,6 +84,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 ActiveScreen::GamefilterSubmenu => menus::gamefilter_menu::render(app),
                 ActiveScreen::ZapretTagSelect => menus::tag_menu::render(&app.available_nfqws_tags, app.nfqws_tag_index, " Select Zapret Tag "),
                 ActiveScreen::StrategyTagSelect => menus::tag_menu::render(&app.available_strat_tags, app.strat_tag_index, " Select Strategy Tag "),
+                ActiveScreen::ServiceSubmenu => menus::service_menu::render(app),
             };
 
             let list_block = Block::default()
@@ -91,12 +93,13 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 .border_type(BorderType::Rounded)
                 .border_style(Theme::dim_item());
 
-            if app.active_screen == ActiveScreen::Main {
+            if app.active_screen == ActiveScreen::Main || app.active_screen == ActiveScreen::ServiceSubmenu {
                 let inner_area = list_block.inner(chunks[1]);
                 let main_chunks = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints([
                         Constraint::Min(1),
+                        Constraint::Length(1),
                         Constraint::Length(1),
                     ])
                     .split(inner_area);
@@ -109,6 +112,41 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 list_state.select(Some(selected_index));
                 f.render_stateful_widget(list, main_chunks[0], &mut list_state);
 
+                // Service Status line
+                let (status_icon, status_color, status_desc) = if !app.service_installed {
+                    ("❌", Color::Red, "Not Installed")
+                } else if app.service_active {
+                    ("✅", Color::Green, "Active (Running)")
+                } else {
+                    ("⏸️", Color::Yellow, "Stopped")
+                };
+
+                let service_type_str = {
+                    #[cfg(target_os = "windows")]
+                    { "Windows Service" }
+                    #[cfg(target_os = "linux")]
+                    {
+                        crate::inits::detect_init_system()
+                            .map(|t| t.as_str())
+                            .unwrap_or("Unknown Init")
+                    }
+                    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+                    { "Unknown Platform" }
+                };
+
+                let service_status_text = Line::from(vec![
+                    Span::styled("⚙️ Service Status (", Style::default().fg(Color::Gray)),
+                    Span::styled(service_type_str, Style::default().fg(Color::White)),
+                    Span::styled("): ", Style::default().fg(Color::Gray)),
+                    Span::styled(status_desc, Style::default().fg(status_color).add_modifier(ratatui::style::Modifier::BOLD)),
+                    Span::raw(" "),
+                    Span::raw(status_icon),
+                ]);
+                let service_status_paragraph = Paragraph::new(service_status_text)
+                    .alignment(ratatui::layout::Alignment::Center);
+                f.render_widget(service_status_paragraph, main_chunks[1]);
+
+                // Dependencies status line
                 let mut show_error = false;
                 let mut error_msg = String::new();
                 if let Some((ref msg, instant)) = app.dependency_error {
@@ -136,7 +174,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 let status_paragraph = Paragraph::new(status_text)
                     .alignment(ratatui::layout::Alignment::Center);
                 
-                f.render_widget(status_paragraph, main_chunks[1]);
+                f.render_widget(status_paragraph, main_chunks[2]);
             } else {
                 let list = List::new(items)
                     .block(list_block)
@@ -156,6 +194,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                     MainMenuState::Interface => "💡 Toggle: Choose network interface. Press SPACE/ENTER to cycle.",
                     MainMenuState::Strategy => "💡 Select: Choose strategy folder or script to use.",
                     MainMenuState::GamefilterSettings => "💡 Submenu: Open TCP/UDP Game Filter ports configuration.",
+                    MainMenuState::ServiceSettings => "💡 Submenu: Open background service status and control configuration.",
                     MainMenuState::Run => "💡 Action: Run Zapret with selected configuration.",
                     MainMenuState::Quit => "💡 Action: Exit the TUI application.",
                 },
@@ -187,6 +226,7 @@ pub fn run_tui(app: &mut AppState) -> Result<(), io::Error> {
                 ActiveScreen::StrategySubmenu => "💡 Strategy Select: Choose a strategy from the downloaded strategies list.",
                 ActiveScreen::ZapretTagSelect => "💡 Select: Use UP/DOWN to navigate, ENTER to select a specific Zapret tag.",
                 ActiveScreen::StrategyTagSelect => "💡 Select: Use UP/DOWN to navigate, ENTER to select a specific Strategies tag.",
+                ActiveScreen::ServiceSubmenu => "💡 Service Control: Select action for the service (start, stop, etc.) or back.",
             };
 
             let help_text = if let Some(ref msg) = app.status_message {


### PR DESCRIPTION
# Изменения
## cargo.toml
- Добавлена платформозависимая зависимость windows-service = "0.6.0" для Windows

## src/main.rs
- Добавлено безусловное объявление модуля inits.
- Реализован запуск диспетчера служб Windows SCM при передаче аргумента --service на старте программы.
src/inits/
- Создан общий интерфейс ServiceManager для управления службами на всех платформах.
- Реализована автодетекция систем инициализации на Linux (detect_init_system()).
- Добавлены реализации для Linux-систем инициализации: Systemd, OpenRC, Runit, Dinit, s6, SysV Init.
- Добавлена реализация для нативной службы Windows SCM (winservice.rs), управляющая WinDivert и winws.exe.
-Все платформозависимые файлы и импорты изолированы директивами условной компиляции #[cfg].

## src/tui/
- В главное меню добавлен пункт ⚙️ Service Settings для настройки службы.
- Реализовано динамическое подменю ServiceSubmenu для установки, удаления, запуска и остановки службы в зависимости от её статуса.
- Добавлена строка центрированного отображения статуса службы прямо над зависимостями на экранах главного меню и подменю.