### PR TITLE
Сохранение конфига при каждом взаимодействии и фикс работы сервиса

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -101,3 +101,14 @@ pub fn save_tui_state(interface: &str, strategy: &str, tcp: bool, udp: bool) -> 
         gamefilter_udp: udp,
     })
 }
+
+pub fn ensure_default_config() -> Result<(), String> {
+    let path = config_path();
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| format!("Cannot create config directory: {}", e))?;
+        }
+        save_config(&RunConfig::default())?;
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,15 +162,6 @@ fn main() {
             use_gamefilter_tcp = app.tcp_gamefilter;
             use_gamefilter_udp = app.udp_gamefilter;
 
-            if let Some(ref strat) = use_strategy {
-                let _ = config::save_tui_state(
-                    &use_interface,
-                    strat,
-                    use_gamefilter_tcp,
-                    use_gamefilter_udp,
-                );
-            }
-
             if app.should_quit {
                 println!("{}", rust_i18n::t!("msg_exited"));
                 return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,15 @@ rust_i18n::i18n!("locales", fallback = "en");
 use clap::Parser;
 use std::process::exit;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+use nix::sys::signal::{self, SigAction, SigHandler, Signal, SaFlags};
+
+static RUNNING: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn handle_signal(_: i32) {
+    RUNNING.store(false, Ordering::SeqCst);
+}
 
 #[cfg(not(target_os = "windows"))]
 use firewalls::nftables::NftablesBackend;
@@ -134,12 +140,12 @@ fn main() {
         is_interactive = false;
     }
 
-    let running = Arc::new(AtomicBool::new(false));
-    let r = running.clone();
-    ctrlc::set_handler(move || {
-        r.store(false, Ordering::SeqCst);
-    })
-    .unwrap_or_else(|e| eprintln!("Error setting Ctrl-C handler: {}", e));
+    let handler = SigHandler::Handler(handle_signal);
+    let sig_action = SigAction::new(handler, SaFlags::empty(), signal::SigSet::empty());
+    unsafe {
+        let _ = signal::sigaction(Signal::SIGTERM, &sig_action);
+        let _ = signal::sigaction(Signal::SIGINT, &sig_action);
+    }
 
     loop {
         if is_interactive {
@@ -220,9 +226,9 @@ fn main() {
         thread::sleep(Duration::from_millis(100));
         println!("{}", rust_i18n::t!("msg_zapret_started"));
 
-        running.store(true, Ordering::SeqCst);
+        RUNNING.store(true, Ordering::SeqCst);
 
-        while running.load(Ordering::SeqCst) {
+        while RUNNING.load(Ordering::SeqCst) {
             thread::sleep(Duration::from_millis(100));
         }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -245,6 +245,8 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(interfaces: Vec<String>, strategies: Vec<String>) -> Self {
+        let _ = crate::config::ensure_default_config();
+
         let saved_cfg = crate::config::load_config(
             &crate::config::config_path().to_string_lossy()
         ).ok();
@@ -347,6 +349,21 @@ impl AppState {
         if count > 0 && self.service_menu_index >= count {
             self.service_menu_index = count - 1;
         }
+    }
+
+    fn save_current_config(&self) {
+        let interface = self.interfaces.get(self.selected_interface)
+            .map(|s| s.as_str())
+            .unwrap_or("any");
+        let strategy = self.strategies.get(self.selected_strategy)
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        let _ = crate::config::save_tui_state(
+            interface,
+            strategy,
+            self.tcp_gamefilter,
+            self.udp_gamefilter,
+        );
     }
 
     pub fn get_service_menu_count(&self) -> usize {
@@ -462,6 +479,7 @@ impl AppState {
                     MainMenuState::Interface => {
                         if !self.interfaces.is_empty() {
                             self.selected_interface = (self.selected_interface + 1) % self.interfaces.len();
+                            self.save_current_config();
                         }
                     }
                     MainMenuState::Strategy => {
@@ -518,6 +536,7 @@ impl AppState {
             ActiveScreen::StrategySubmenu => {
                 if self.strategy_menu_index < self.strategies.len() {
                     self.selected_strategy = self.strategy_menu_index;
+                    self.save_current_config();
                     self.active_screen = ActiveScreen::Main;
                     self.status_message = Some(format!("\u{F00C} Selected strategy: {}", self.strategies[self.selected_strategy]));
                 } else {
@@ -626,8 +645,14 @@ impl AppState {
             }
             ActiveScreen::GamefilterSubmenu => {
                 match self.gamefilter_menu {
-                    GamefilterMenuState::Tcp => self.tcp_gamefilter = !self.tcp_gamefilter,
-                    GamefilterMenuState::Udp => self.udp_gamefilter = !self.udp_gamefilter,
+                    GamefilterMenuState::Tcp => {
+                        self.tcp_gamefilter = !self.tcp_gamefilter;
+                        self.save_current_config();
+                    }
+                    GamefilterMenuState::Udp => {
+                        self.udp_gamefilter = !self.udp_gamefilter;
+                        self.save_current_config();
+                    }
                     GamefilterMenuState::Back => {
                         self.active_screen = ActiveScreen::Main;
                         self.status_message = None;
@@ -746,6 +771,7 @@ impl AppState {
                             } else {
                                 self.selected_interface = (self.selected_interface + len - 1) % len;
                             }
+                            self.save_current_config();
                         }
                     }
                     _ => {
@@ -781,8 +807,14 @@ impl AppState {
             }
             ActiveScreen::GamefilterSubmenu => {
                 match self.gamefilter_menu {
-                    GamefilterMenuState::Tcp => self.tcp_gamefilter = !self.tcp_gamefilter,
-                    GamefilterMenuState::Udp => self.udp_gamefilter = !self.udp_gamefilter,
+                    GamefilterMenuState::Tcp => {
+                        self.tcp_gamefilter = !self.tcp_gamefilter;
+                        self.save_current_config();
+                    }
+                    GamefilterMenuState::Udp => {
+                        self.udp_gamefilter = !self.udp_gamefilter;
+                        self.save_current_config();
+                    }
                     _ => {
                         if forward {
                             self.toggle_current();


### PR DESCRIPTION
Сохранение conf.env после каждого действия пользователя
- При старте TUI проверяется наличие conf.env; если файла нет — автоматически создаётся с дефолтными настройками (interface=any, gamefiltertcp=false, gamefilterudp=false)
- Добавлен метод save_current_config(), который вызывается сразу после каждого изменения любого параметра:
- Убран дублирующий вызов save_tui_state после выхода из TUI в main.rs — теперь сохранение происходит инкрементально
Фикс очищения таблицы файрвола при остановке/удалении сервиса
Проблема: systemctl stop zapret-rust / service zapret-rust stop посылает SIGTERM, но обработчик был только на SIGINT (через ctrlc). Процесс просто убивался, и stop_zapret() не вызывался — правила nftables/iptables оставались в системе.
Решение: Заменён ctrlc::set_handler на nix::sys::signal::sigaction с обработчиком и для SIGINT, и для SIGTERM. При получении любого из этих сигналов цикл корректно завершается, вызывается stop_zapret(), который чистит таблицу фаервола и убивает nfqws.