### PR TITLE
Добавление логов запуска nfqws

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,284 @@
+use std::env;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::process::Command;
+
+pub fn log_nfqws_launch(bin_path: &str, nfqws_params: &[String], terminal_output: &[String]) {
+    let log_dir = crate::config::get_cache_dir().join("logs");
+    let log_file = log_dir.join("zapret.log");
+
+    if fs::create_dir_all(&log_dir).is_err() {
+        return;
+    }
+
+    let mut file = match OpenOptions::new().create(true).write(true).truncate(true).open(&log_file) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    let ts = timestamp();
+
+    let _ = writeln!(file, "===== nfqws | {} =====", ts);
+    let _ = writeln!(file, "");
+
+    let _ = writeln!(file, "--- System Info ---");
+    for line in collect_system_info() {
+        let _ = writeln!(file, "{}", line);
+    }
+    let _ = writeln!(file, "");
+
+    let config_path = crate::config::config_path();
+    let config_content = fs::read_to_string(&config_path).unwrap_or_default();
+    let _ = writeln!(file, "--- Config ---");
+    let _ = write!(file, "{}", config_content);
+    let _ = writeln!(file, "");
+
+    if !terminal_output.is_empty() {
+        let _ = writeln!(file, "--- Terminal ---");
+        for line in terminal_output {
+            let _ = writeln!(file, "{}", line);
+        }
+        let _ = writeln!(file, "");
+    }
+
+    let _ = writeln!(file, "--- Strategy params ---");
+    let _ = writeln!(file, "binary: {}", bin_path);
+    for param in nfqws_params {
+        let _ = writeln!(file, "{}", param);
+    }
+}
+
+fn collect_system_info() -> Vec<String> {
+    let mut info = Vec::new();
+
+    info.push(format!("OS: {}", env::consts::OS));
+    info.push(format!("Arch: {}", env::consts::ARCH));
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(output) = Command::new("uname").arg("-r").output() {
+            if let Ok(s) = String::from_utf8(output.stdout) {
+                let v = s.trim();
+                if !v.is_empty() {
+                    info.push(format!("Kernel: {}", v));
+                }
+            }
+        }
+
+        if let Ok(content) = fs::read_to_string("/etc/os-release") {
+            for line in content.lines() {
+                if let Some(val) = line.strip_prefix("PRETTY_NAME=") {
+                    info.push(format!("Distro: {}", val.trim_matches('"')));
+                    break;
+                }
+            }
+        }
+
+        let modules_raw = fs::read_to_string("/proc/modules").unwrap_or_default();
+        let nf_modules: Vec<&str> = modules_raw.lines()
+            .filter_map(|l| {
+                let name = l.split_whitespace().next()?;
+                if name.starts_with("nf_") || name.starts_with("nft_")
+                    || name.starts_with("ip_t") || name.starts_with("ip6_t")
+                    || name.starts_with("iptable") || name.starts_with("ip6table")
+                    || name == "arptables" || name == "ebtables"
+                {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if nf_modules.is_empty() {
+            info.push("Netfilter modules: none loaded".to_string());
+        } else {
+            info.push(format!("Netfilter modules: {}", nf_modules.join(", ")));
+        }
+
+        for tool in &["nft", "iptables", "iptables-nft"] {
+            let ok = Command::new(tool)
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false);
+            info.push(format!("{}: {}", tool, if ok { "available" } else { "not found" }));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(output) = Command::new("cmd").args(["/c", "ver"]).output() {
+            if let Ok(s) = String::from_utf8(output.stdout) {
+                info.push(format!("Windows: {}", s.trim()));
+            }
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(entries) = fs::read_dir("/sys/class/net") {
+            let mut interfaces: Vec<String> = entries
+                .flatten()
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect();
+            interfaces.sort();
+            let iface_str = if interfaces.is_empty() {
+                "none".to_string()
+            } else {
+                interfaces.join(", ")
+            };
+            info.push(format!("Interfaces: {}", iface_str));
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let interfaces = crate::config::get_interfaces();
+        info.push(format!("Interfaces: {}", interfaces.join(", ")));
+    }
+
+    let cache_dir = crate::config::get_cache_dir();
+
+    let bin_dir = cache_dir.join("bin");
+    let bin_name = if env::consts::OS == "windows" { "winws.exe" } else { "nfqws" };
+    let bin_path = bin_dir.join(bin_name);
+    if bin_path.exists() {
+        info.push("nfqws: installed".to_string());
+        if let Ok(output) = Command::new(&bin_path).arg("--version").output() {
+            if let Ok(s) = String::from_utf8(output.stdout) {
+                let ver = s.lines().next().unwrap_or("").trim().to_string();
+                if !ver.is_empty() {
+                    info.push(format!("nfqws version: {}", ver));
+                }
+            }
+            if let Ok(s) = String::from_utf8(output.stderr) {
+                let ver = s.lines().next().unwrap_or("").trim().to_string();
+                if !ver.is_empty() && !info.iter().any(|l| l.starts_with("nfqws version:")) {
+                    info.push(format!("nfqws version: {}", ver));
+                }
+            }
+        }
+    } else {
+        info.push("nfqws: not installed".to_string());
+    }
+
+    let strat_dir = cache_dir.join("zapret-discord-youtube-linux");
+    if strat_dir.exists() {
+        let mut count = 0;
+        if let Ok(entries) = fs::read_dir(&strat_dir) {
+            for entry in entries.flatten() {
+                if let Ok(name) = entry.file_name().into_string() {
+                    if name.ends_with(".bat") {
+                        count += 1;
+                    }
+                }
+            }
+        }
+        if let Ok(entries) = fs::read_dir(strat_dir.join("custom-strategies")) {
+            for entry in entries.flatten() {
+                if let Ok(name) = entry.file_name().into_string() {
+                    if name.ends_with(".bat") {
+                        count += 1;
+                    }
+                }
+            }
+        }
+        let version_file = strat_dir.join(".service").join("version.txt");
+        let ver = fs::read_to_string(&version_file).unwrap_or_default();
+        let ver_str = ver.trim();
+        if ver_str.is_empty() {
+            info.push(format!("Strategies: {} .bat files", count));
+        } else {
+            info.push(format!("Strategies: {} .bat files (version {})", count, ver_str));
+        }
+    } else {
+        info.push("Strategies: not installed".to_string());
+    }
+
+    info.push(format!("User: {}",
+        env::var("USER").unwrap_or_else(|_| env::var("USERNAME").unwrap_or_default())));
+    info.push(format!("Cache dir: {}", cache_dir.display()));
+
+    info
+}
+
+pub fn log_stop(stop_output: &[String]) {
+    let log_file = crate::config::get_cache_dir().join("logs").join("zapret.log");
+    let mut file = match OpenOptions::new().create(true).append(true).open(&log_file) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    let ts = timestamp();
+    let _ = writeln!(file, "");
+    let _ = writeln!(file, "===== stop | {} =====", ts);
+    for line in stop_output {
+        let _ = writeln!(file, "{}", line);
+    }
+}
+
+fn timestamp() -> String {
+    #[cfg(target_os = "linux")]
+    if let Ok(output) = Command::new("date").args(["+%Y-%m-%d %H:%M:%S"]).output() {
+        if let Ok(s) = String::from_utf8(output.stdout) {
+            let t = s.trim().to_string();
+            if !t.is_empty() {
+                return t;
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    if let Ok(output) = Command::new("cmd").args(["/c", "echo %DATE% %TIME%"]).output() {
+        if let Ok(s) = String::from_utf8(output.stdout) {
+            let t = s.trim().to_string();
+            if !t.is_empty() {
+                return t;
+            }
+        }
+    }
+
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let total_secs = dur.as_secs();
+
+    let days = total_secs / 86400;
+    let time = total_secs % 86400;
+    let hours = time / 3600;
+    let minutes = (time % 3600) / 60;
+    let seconds = time % 60;
+
+    fn is_leap(year: u64) -> bool {
+        (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+    }
+
+    let mut y = 1970i64;
+    let mut remaining = days as i64;
+    loop {
+        let days_in_year = if is_leap(y as u64) { 366 } else { 365 };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+
+    let month_days: &[i64] = if is_leap(y as u64) {
+        &[31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        &[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    let mut m = 0u32;
+    for (i, &days_in_m) in month_days.iter().enumerate() {
+        if remaining < days_in_m {
+            m = (i + 1) as u32;
+            break;
+        }
+        remaining -= days_in_m;
+    }
+    let d = remaining + 1;
+
+    format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, m, d, hours, minutes, seconds)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod strategy;
 mod tui;
 mod utils;
 mod ipset;
+mod logger;
 
 rust_i18n::i18n!("locales", fallback = "en");
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
 
 static NFQWS_PROCESSES: Mutex<Vec<Child>> = Mutex::new(Vec::new());
 
@@ -16,6 +18,8 @@ pub fn run_zapret(
     use_udp: bool,
     backend: &dyn FirewallBackend,
 ) {
+    let mut term: Vec<String> = Vec::new();
+
     // 1. Parse strategy file
     let repo_dir = env::var("REPO_DIR").unwrap_or_else(|_| {
         crate::config::get_cache_dir()
@@ -69,7 +73,9 @@ pub fn run_zapret(
     }
 
     // 5. Start nfqws
-    println!("{}", rust_i18n::t!("msg_start_nfqws"));
+    let msg = rust_i18n::t!("msg_start_nfqws").to_string();
+    term.push(msg.clone());
+    println!("{}", msg);
 
     let bin_dir = crate::config::get_cache_dir().join("bin");
     let bin_name = if env::consts::OS == "windows" {
@@ -80,7 +86,9 @@ pub fn run_zapret(
     let bin_path = bin_dir.join(bin_name);
 
     if !bin_path.exists() {
-        println!("{}", rust_i18n::t!("err_bin_miss").replace("{:?}", &format!("{:?}", bin_path)));
+        let msg = rust_i18n::t!("err_bin_miss").replace("{:?}", &format!("{:?}", bin_path));
+        term.push(msg.clone());
+        println!("{}", msg);
         return;
     }
 
@@ -90,7 +98,11 @@ pub fn run_zapret(
         .output();
     match cap_status {
         Ok(o) if o.status.success() => (),
-        _ => println!("{}", rust_i18n::t!("err_setcap")),
+        _ => {
+            let msg = rust_i18n::t!("err_setcap").to_string();
+            term.push(msg.clone());
+            println!("{}", msg);
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -114,18 +126,69 @@ pub fn run_zapret(
         }
     }
 
-    println!("{}{:?} {:?}", rust_i18n::t!("msg_cmd"), bin_path, args);
-    match Command::new(&bin_path).args(&args).current_dir(&repo_path).spawn() {
+    let cmd_msg = format!("{}{:?} {:?}", rust_i18n::t!("msg_cmd"), bin_path, args);
+    term.push(cmd_msg.clone());
+    println!("{}", cmd_msg);
+
+    // Capture nfqws output to a temp file
+    let tmp_log = crate::config::get_cache_dir().join("logs").join("nfqws_output.tmp");
+    let _ = fs::create_dir_all(tmp_log.parent().unwrap());
+    let output_file = match fs::File::create(&tmp_log) {
+        Ok(f) => f,
+        Err(_) => {
+            let msg = format!("failed to create temp log file");
+            term.push(msg.clone());
+            println!("{}", msg);
+            return;
+        }
+    };
+
+    let out_dup = match output_file.try_clone() {
+        Ok(f) => f,
+        Err(_) => {
+            let msg = format!("failed to clone temp log file handle");
+            term.push(msg.clone());
+            println!("{}", msg);
+            return;
+        }
+    };
+
+    match Command::new(&bin_path)
+        .args(&args)
+        .current_dir(&repo_path)
+        .stdout(output_file)
+        .stderr(out_dup)
+        .spawn()
+    {
         Ok(child) => {
             if let Ok(mut procs) = NFQWS_PROCESSES.lock() {
                 procs.push(child);
             }
-            println!("{}", rust_i18n::t!("msg_nfqws_run"));
+
+            let msg = rust_i18n::t!("msg_nfqws_run").to_string();
+            term.push(msg.clone());
+            println!("{}", msg);
+
+            // Wait briefly for nfqws startup output
+            thread::sleep(Duration::from_millis(300));
+
+            // Read captured output
+            let nfqws_out = fs::read_to_string(&tmp_log).unwrap_or_default();
+            let _ = fs::remove_file(&tmp_log);
+
+            if !nfqws_out.is_empty() {
+                term.push(nfqws_out.clone());
+                print!("{}", nfqws_out);
+            }
         }
         Err(e) => {
-            println!("{}{}", rust_i18n::t!("err_start_nfqws"), e);
+            let msg = format!("{}{}", rust_i18n::t!("err_start_nfqws"), e);
+            term.push(msg.clone());
+            println!("{}", msg);
         }
     }
+
+    crate::logger::log_nfqws_launch(&bin_path.to_string_lossy(), &parsed.nfqws_params, &term);
 }
 
 /// Run zapret silently for autotune (no println, returns Result).
@@ -215,6 +278,7 @@ pub fn run_zapret_silent(
         }
     }
 
+    crate::logger::log_nfqws_launch(&bin_path.to_string_lossy(), &parsed.nfqws_params, &[]);
     match Command::new(&bin_path).args(&args).current_dir(&repo_path).spawn() {
         Ok(child) => {
             if let Ok(mut procs) = NFQWS_PROCESSES.lock() {
@@ -228,7 +292,12 @@ pub fn run_zapret_silent(
 
 /// Clear the firewall rules and stop any running processes.
 pub fn stop_zapret(backend: &dyn FirewallBackend) {
-    println!("{}", rust_i18n::t!("msg_zapret_stop"));
+    let mut term: Vec<String> = Vec::new();
+
+    let msg = rust_i18n::t!("msg_zapret_stop").to_string();
+    term.push(msg.clone());
+    println!("{}", msg);
+
     if let Ok(mut procs) = NFQWS_PROCESSES.lock() {
         for child in procs.iter_mut() {
             let _ = child.kill();
@@ -236,6 +305,12 @@ pub fn stop_zapret(backend: &dyn FirewallBackend) {
         }
         procs.clear();
     }
+
     let _ = backend.clear();
-    println!("{}", rust_i18n::t!("msg_zapret_clear"));
+
+    let msg = rust_i18n::t!("msg_zapret_clear").to_string();
+    term.push(msg.clone());
+    println!("{}", msg);
+
+    crate::logger::log_stop(&term);
 }


### PR DESCRIPTION
Новый модуль src/logger.rs — логирование запуска и остановки nfqws.
- При каждом запуске nfqws создаётся/перезаписывается файл <cache_dir>/logs/zapret.log
- При остановке nfqws в лог дописывается секция stop
- Все таймстемпы берутся из локального времени системы
Лог содержит:
Секция	Данные
--- System Info ---	ОС, архитектура, ядро, дистрибутив, загруженные модули netfilter (nf_tables, nfnetlink_queue, ip_tables и др.), доступность nft/iptables/iptables-nft, версия nfqws, количество стратегий + версия, список сетевых интерфейсов
--- Config ---	Содержимое conf.env (конфиг пользователя)
--- Terminal ---	Полный вывод терминала при запуске: сообщения программы + вывод самого nfqws (версия, загрузка hostlist'ов, привязка очереди и т.д.)
--- Strategy params ---	Параметры запуска nfqws в оригинальном многострочном формате из .bat файла
===== stop =====	Вывод терминала при остановке nfqws (очистка правил, убийство процессов)
Затронутые файлы
- src/logger.rs — новый модуль
- src/runner.rs — логирование запуска/остановки nfqws, захват stdout/stderr nfqws во временный файл
- src/main.rs — добавлен mod logger