### PR TITLE
refactor: replace shell commands with crate libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +142,12 @@ checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base62"
@@ -251,6 +266,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +374,12 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpubits"
@@ -790,6 +824,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1016,15 @@ dependencies = [
  "thiserror 1.0.69",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "is_elevated"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299060ff5db63e788015dcb9525ad9b84f4fd9717ed2cbdeba5018cbf42f9b5"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1175,10 +1242,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "objc2"
@@ -1190,10 +1275,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -1885,6 +2012,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,10 +2443,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-service"
@@ -2315,6 +2543,15 @@ dependencies = [
  "bitflags 1.3.2",
  "widestring",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2397,6 +2634,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2679,12 +2925,14 @@ version = "2.0.0"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
+ "chrono",
  "clap",
  "crossterm 0.27.0",
  "ctrlc",
  "flate2",
  "hmac 0.12.1",
  "inquire",
+ "is_elevated",
  "nftables",
  "nix 0.27.1",
  "ratatui",
@@ -2693,6 +2941,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sys-locale",
+ "sysinfo",
  "tar",
  "ureq",
  "windows-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ aes = "0.8"
 aes-gcm = "0.10"
 hmac = "0.12"
 sha2 = "0.10"
+sysinfo = "0.39.6"
+chrono = "0.4.45"
+is_elevated = "0.1.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-service = "0.6.0"

--- a/src/autotune/types.rs
+++ b/src/autotune/types.rs
@@ -16,21 +16,16 @@ pub fn trigger_cancel() {
 }
 
 pub fn kill_active_curls() {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    
     #[cfg(target_os = "windows")]
-    {
-        let _ = std::process::Command::new("taskkill")
-            .args(["/F", "/IM", "curl.exe", "/T"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-    }
+    let bin_name = "curl.exe";
     #[cfg(not(target_os = "windows"))]
-    {
-        let _ = std::process::Command::new("pkill")
-            .args(["-9", "curl"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
+    let bin_name = "curl";
+    
+    for process in sys.processes_by_exact_name(std::ffi::OsStr::new(bin_name)) {
+        process.kill();
     }
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -61,22 +61,14 @@ fn collect_system_info() -> Vec<String> {
 
     #[cfg(target_os = "linux")]
     {
-        if let Ok(output) = Command::new("uname").arg("-r").output() {
-            if let Ok(s) = String::from_utf8(output.stdout) {
-                let v = s.trim();
-                if !v.is_empty() {
-                    info.push(format!("Kernel: {}", v));
-                }
-            }
+        if let Some(v) = sysinfo::System::kernel_version() {
+            info.push(format!("Kernel: {}", v));
         }
 
-        if let Ok(content) = fs::read_to_string("/etc/os-release") {
-            for line in content.lines() {
-                if let Some(val) = line.strip_prefix("PRETTY_NAME=") {
-                    info.push(format!("Distro: {}", val.trim_matches('"')));
-                    break;
-                }
-            }
+        if let Some(name) = sysinfo::System::long_os_version() {
+            info.push(format!("Distro: {}", name));
+        } else if let Some(name) = sysinfo::System::name() {
+            info.push(format!("Distro: {}", name));
         }
 
         let modules_raw = fs::read_to_string("/proc/modules").unwrap_or_default();
@@ -117,10 +109,10 @@ fn collect_system_info() -> Vec<String> {
 
     #[cfg(target_os = "windows")]
     {
-        if let Ok(output) = Command::new("cmd").args(["/c", "ver"]).output() {
-            if let Ok(s) = String::from_utf8(output.stdout) {
-                info.push(format!("Windows: {}", s.trim()));
-            }
+        if let Some(v) = sysinfo::System::long_os_version() {
+            info.push(format!("Windows: {}", v));
+        } else if let Some(name) = sysinfo::System::name() {
+            info.push(format!("Windows: {}", name));
         }
     }
 
@@ -234,67 +226,16 @@ pub fn log_stop(stop_output: &[String]) {
 }
 
 fn timestamp() -> String {
-    #[cfg(target_os = "linux")]
-    if let Ok(output) = Command::new("date").args(["+%Y-%m-%d %H:%M:%S"]).output() {
-        if let Ok(s) = String::from_utf8(output.stdout) {
-            let t = s.trim().to_string();
-            if !t.is_empty() {
-                return t;
-            }
-        }
+    chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_sysinfo_output() {
+        println!("SysInfo: {:#?}", collect_system_info());
+        println!("Timestamp: {}", timestamp());
     }
-
-    #[cfg(target_os = "windows")]
-    if let Ok(output) = Command::new("cmd").args(["/c", "echo %DATE% %TIME%"]).output() {
-        if let Ok(s) = String::from_utf8(output.stdout) {
-            let t = s.trim().to_string();
-            if !t.is_empty() {
-                return t;
-            }
-        }
-    }
-
-    let dur = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    let total_secs = dur.as_secs();
-
-    let days = total_secs / 86400;
-    let time = total_secs % 86400;
-    let hours = time / 3600;
-    let minutes = (time % 3600) / 60;
-    let seconds = time % 60;
-
-    fn is_leap(year: u64) -> bool {
-        (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
-    }
-
-    let mut y = 1970i64;
-    let mut remaining = days as i64;
-    loop {
-        let days_in_year = if is_leap(y as u64) { 366 } else { 365 };
-        if remaining < days_in_year {
-            break;
-        }
-        remaining -= days_in_year;
-        y += 1;
-    }
-
-    let month_days: &[i64] = if is_leap(y as u64) {
-        &[31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    } else {
-        &[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    };
-
-    let mut m = 0u32;
-    for (i, &days_in_m) in month_days.iter().enumerate() {
-        if remaining < days_in_m {
-            m = (i + 1) as u32;
-            break;
-        }
-        remaining -= days_in_m;
-    }
-    let d = remaining + 1;
-
-    format!("{:04}-{:02}-{:02} {:02}:{:02}:{:02}", y, m, d, hours, minutes, seconds)
 }

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -5,13 +5,7 @@ use std::os::unix::process::CommandExt;
 /// Ensures that the current process is running with root privileges.
 /// If not, it attempts to escalate privileges using pkexec or sudo.
 pub fn ensure_admin() {
-    let not_root = std::process::Command::new("id")
-        .arg("-u")
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim() != "0")
-        .unwrap_or(true);
+    let not_root = !is_elevated::is_elevated();
 
     if not_root {
         println!("{}", rust_i18n::t!("root_req"));
@@ -35,10 +29,8 @@ pub fn ensure_admin() {
 }
 
 pub fn is_nfqws_running() -> bool {
-    std::process::Command::new("pgrep")
-        .arg("-x")
-        .arg("nfqws")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let is_running = sys.processes_by_exact_name(std::ffi::OsStr::new("nfqws")).next().is_some();
+    is_running
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3,16 +3,7 @@
 /// Ensures that the current process is running with elevated (Administrator) privileges.
 /// If not, it requests UAC elevation by spawning a new PowerShell process and exits the current process.
 pub fn ensure_admin() {
-    let output = std::process::Command::new("fsutil")
-        .arg("dirty")
-        .arg("query")
-        .arg(std::env::var("SystemDrive").unwrap_or_else(|_| "C:".to_string()))
-        .output();
-
-    let is_elevated = match output {
-        Ok(out) => out.status.success(),
-        Err(_) => false,
-    };
+    let is_elevated = is_elevated::is_elevated();
 
     if !is_elevated {
         println!("Requesting Administrator privileges...");
@@ -37,10 +28,8 @@ pub fn ensure_admin() {
 }
 
 pub fn is_nfqws_running() -> bool {
-    let out = std::process::Command::new("tasklist")
-        .args(["/FI", "IMAGENAME eq winws.exe", "/NH"])
-        .output()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_default();
-    out.contains("winws.exe")
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let is_running = sys.processes_by_exact_name(std::ffi::OsStr::new("winws.exe")).next().is_some();
+    is_running
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -20,14 +20,18 @@ pub fn nfqws_process_running() -> bool {
         .any(|p| p.try_wait().map(|s| s.is_none()).unwrap_or(false))
 }
 
-#[cfg(target_os = "linux")]
 fn kill_stale_zapret() {
-    let _ = Command::new("pkill").arg("-9").arg("nfqws").output();
-}
-
-#[cfg(target_os = "windows")]
-fn kill_stale_zapret() {
-    let _ = Command::new("taskkill").args(["/F", "/IM", "winws.exe"]).output();
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    
+    #[cfg(target_os = "windows")]
+    let bin_name = "winws.exe";
+    #[cfg(not(target_os = "windows"))]
+    let bin_name = "nfqws";
+    
+    for process in sys.processes_by_exact_name(std::ffi::OsStr::new(bin_name)) {
+        process.kill();
+    }
 }
 
 fn repo_path() -> PathBuf {


### PR DESCRIPTION
- Replace `uname`/`ver` in logger with native OS queries
- Replace `pgrep`/`tasklist` for checking process status
- Replace `pkill`/`taskkill` for killing stale processes
- Add `sysinfo` dependency